### PR TITLE
#4: update to 1password-cli@beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Bootbox is designed to be run directly from the hosted script at
 - It supports installing into the default home directory target or a custom `--target`.
 - For 1Password-backed SSH keys, provide a service account token with `--op-token`,
   `TANAAB_OP_TOKEN`, or `OP_SERVICE_ACCOUNT_TOKEN`.
+- Bootbox currently installs the beta 1Password CLI cask because downstream machine profiles need
+  Environment commands such as `op run --environment`. This should return to stable
+  `1password-cli` once stable 1Password CLI includes that support.
 - The hosted URL serves the generated `dist/bootbox.sh` entrypoint used for releases.
 
 ## Usage

--- a/bootbox.sh
+++ b/bootbox.sh
@@ -711,7 +711,7 @@ default_homebrew_prefix() {
 # core packages that should be present regardless of any user-provided Brewfile
 declare -a TANAAB_CORE_BREW_PACKAGES=(
   "formula|git|git"
-  "cask|1password-cli|op"
+  "cask|1password-cli@beta|op"
   "formula|curl|curl"
   "formula|zsh|zsh"
   "formula|jq|jq"

--- a/examples/bootbox-minimal/README.md
+++ b/examples/bootbox-minimal/README.md
@@ -44,6 +44,12 @@ command -v stow >/dev/null || test -x /opt/homebrew/bin/stow || test -x /usr/loc
 
 # should make 1password cli available
 command -v op >/dev/null || test -x /opt/homebrew/bin/op || test -x /usr/local/bin/op
+
+# should install the beta 1password cli cask
+brew list --cask 1password-cli@beta
+
+# should expose 1password environment support
+op run --help | grep -F -- '--environment'
 ```
 
 ## Destroy tests


### PR DESCRIPTION
## Summary

- Install the beta `1password-cli@beta` cask as Bootbox's core `op` provider.
- Document why Bootbox temporarily uses the beta cask for 1Password Environment support.
- Extend the minimal Leia example to assert both the beta cask and `op run --environment` support.

## Validation

- `bun run lint:shellcheck`
- `bun run format:check`
- `bun run lint`

Closes #4