### PR TITLE
Align Bootbox repo metadata and CLI contract

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: 'bun'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types: ['major', 'minor', 'patch']
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      actions:
+        applies-to: version-updates
+        update-types: ['major', 'minor', 'patch']
+    ignore:
+      - dependency-name: 'tanaabased/prepare-release-action'
+        versions: ['99', '99.x.x'] # v99 used for internal testing

--- a/.github/workflows/pr-examples-tests.yml
+++ b/.github/workflows/pr-examples-tests.yml
@@ -22,9 +22,10 @@ jobs:
           - bootbox-brewfiles-flags
           - bootbox-brewfiles-env
           - bootbox-ssh-keys-flags
+          - bootbox-legacy-env-compat
     env:
       HOMEBREW_NO_AUTO_UPDATE: '1'
-      TANAAB_OP_TESTVAULT: ${{ secrets.TANAAB_OP_TESTVAULT }}
+      BOOTBOX_OP_TESTVAULT: ${{ secrets.TANAAB_OP_TESTVAULT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pr-examples-tests.yml
+++ b/.github/workflows/pr-examples-tests.yml
@@ -51,5 +51,6 @@ jobs:
       - name: Run Leia-backed example
         shell: bash
         run: |
+          brew update
           mkdir -p examples/.tmp
           TMPDIR="$PWD/examples/.tmp" ./node_modules/.bin/leia "examples/${{ matrix.example }}/README.md" -c "Destroy tests" --stdin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ When this file conflicts with broader defaults, this file wins for work in `boot
   for Bootbox's built-in Homebrew core only.
 - Keep `--check-core` quiet under normal operation; if its behavior changes, update the CLI
   contract example explicitly.
+- Keep `--no-sudo` as a strict no-elevation mode: no sudo probes, prompts, timestamp cleanup, or
+  sudo-backed helper operations.
 - Keep planned-action output aligned with actual execution order.
 
 ## Secrets And Logging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ When this file conflicts with broader defaults, this file wins for work in `boot
 ## Secrets And Logging
 
 - Never print raw 1Password service account credentials in debug, help, or error output.
-- Mask token-bearing values from `--op-token`, `TANAAB_OP_TOKEN`, and
+- Mask token-bearing values from `--op-token`, `BOOTBOX_OP_TOKEN`, legacy `TANAAB_OP_TOKEN`, and
   `OP_SERVICE_ACCOUNT_TOKEN` when they appear in any diagnostic surface.
 - Preserve the repo's CLI color conventions for status verbs and targets; use the established
   Tanaab styles rather than ad hoc color choices for action labels such as `running`.
@@ -88,7 +88,7 @@ When this file conflicts with broader defaults, this file wins for work in `boot
 - Do not treat local `dist/` regeneration as part of normal validation; if build-artifact
   verification matters, say it was deferred to CI.
 - Live 1Password-backed SSH key validation remains CI-owned because it depends on the
-  `TANAAB_OP_TESTVAULT` secret on fresh macOS runners.
+  `BOOTBOX_OP_TESTVAULT` CI environment value on fresh macOS runners.
 
 ## Release And Distribution
 
@@ -103,8 +103,8 @@ When this file conflicts with broader defaults, this file wins for work in `boot
 
 ## `bootbox.sh` Invariants
 
-- Preserve the public `TANAAB_*` namespace unless the task explicitly changes Bootbox's upstream
-  interface.
+- Preserve the public `BOOTBOX_*` namespace. Legacy `TANAAB_*` support is compatibility-only and
+  should not be documented outside code or explicit legacy behavior tests.
 - Preserve `--check-core` as a hidden, quiet probe for built-in Homebrew core readiness only.
 - Preserve token masking in debug output and do not reintroduce raw argument logging.
 - Keep repeatable CLI inputs replacing env-sourced lists when any corresponding CLI flag is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,10 @@ When this file conflicts with broader defaults, this file wins for work in `boot
 
 ## Purpose
 
-- This repo owns Bootbox, the reusable upstream macOS 26.x bootstrap layer for Homebrew,
+- This repo owns `bootbox`, the reusable upstream macOS 26.x bootstrap layer for Homebrew,
   Brewfiles, dotpackages, and 1Password-backed SSH key material.
-- Downstream machine profiles such as `me`, `emori`, and `agentbox` may wrap Bootbox, but wrapper
-  concerns should stay in those repos unless Bootbox's generic contract is intentionally changed.
+- Downstream machine profiles such as `me`, `emori`, and `agentbox` may wrap `bootbox`, but wrapper
+  concerns should stay in those repos unless `bootbox`'s generic contract is intentionally changed.
 
 ## Source Of Truth
 
@@ -23,6 +23,14 @@ When this file conflicts with broader defaults, this file wins for work in `boot
 - [`scripts/build-dist.js`](/Users/pirog/tanaab/bootbox/scripts/build-dist.js),
   [`site/`](/Users/pirog/tanaab/bootbox/site), `netlify.toml`, release workflows, and committed
   `dist/` files own the hosted-script publishing surface.
+
+## Naming And Style
+
+- In markdown and docs prose, stylize this project as `bootbox`.
+- Markdown H1 titles in `examples/**/README.md` may capitalize the leading `B` when the title
+  starts with the project name.
+- Preserve literal identifiers exactly as written, including commands, paths, URLs, environment
+  variables, labels, generated strings, repository names, and fixture values.
 
 ## Build Artifacts
 
@@ -47,7 +55,7 @@ When this file conflicts with broader defaults, this file wins for work in `boot
 - Any `bootbox.sh` public interface change must check `README.md`, `examples/bootbox-cli-contract`,
   and the affected mutating examples.
 - Keep `--check-core` hidden from `--help`; it is an intentionally undocumented 0/1 readiness probe
-  for Bootbox's built-in Homebrew core only.
+  for `bootbox`'s built-in Homebrew core only.
 - Keep `--check-core` quiet under normal operation; if its behavior changes, update the CLI
   contract example explicitly.
 - Keep `--no-sudo` as a strict no-elevation mode: no sudo probes, prompts, timestamp cleanup, or
@@ -96,7 +104,7 @@ When this file conflicts with broader defaults, this file wins for work in `boot
 
 - Netlify publishes committed `dist/`, but local agents should not update it directly; CI/release
   workflows own generated `dist/` changes.
-- Release workflows use the Bootbox-style shell-script distribution flow. Keep `dist/bootbox.sh` as
+- Release workflows use the `bootbox`-style shell-script distribution flow. Keep `dist/bootbox.sh` as
   the stamped hosted entrypoint.
 - Do not add unrelated package archives or upload behavior unless the release contract explicitly
   changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,115 @@
-# Repo Agent Guidance
+# Repo Guidance For `bootbox`
 
 Apply broader or global Codex guidance first, then apply this repo-local file.
 When this file conflicts with broader defaults, this file wins for work in `bootbox`.
 
+## Purpose
+
+- This repo owns Bootbox, the reusable upstream macOS 26.x bootstrap layer for Homebrew,
+  Brewfiles, dotpackages, and 1Password-backed SSH key material.
+- Downstream machine profiles such as `me`, `emori`, and `agentbox` may wrap Bootbox, but wrapper
+  concerns should stay in those repos unless Bootbox's generic contract is intentionally changed.
+
+## Source Of Truth
+
+- [`bootbox.sh`](/Users/pirog/tanaab/bootbox/bootbox.sh) is the source shell entrypoint and main
+  bootstrap surface.
+- [`README.md`](/Users/pirog/tanaab/bootbox/README.md) is the human-facing setup, usage, and support
+  surface.
+- [`examples/**/README.md`](/Users/pirog/tanaab/bootbox/examples) files are Leia-backed executable
+  contract specs consumed in CI.
+- [`dist/`](/Users/pirog/tanaab/bootbox/dist) is generated publish output for Netlify hosting and
+  release preparation.
+- [`scripts/build-dist.js`](/Users/pirog/tanaab/bootbox/scripts/build-dist.js),
+  [`site/`](/Users/pirog/tanaab/bootbox/site), `netlify.toml`, release workflows, and committed
+  `dist/` files own the hosted-script publishing surface.
+
 ## Build Artifacts
 
-- Treat `dist/` as CI-owned generated output.
-- Do not run `bun run build` locally unless the user explicitly asks for a local build.
-- Do not hand-edit generated files under `dist/`; make source changes in repo-owned inputs such as [`bootbox.sh`](/Users/pirog/tanaab/bootbox/bootbox.sh), [`site/`](/Users/pirog/tanaab/bootbox/site), or [`scripts/build-dist.js`](/Users/pirog/tanaab/bootbox/scripts/build-dist.js) and leave artifact generation to CI unless the user explicitly asks otherwise.
-- Treat [`bootbox.sh`](/Users/pirog/tanaab/bootbox/bootbox.sh) as the source entrypoint and `dist/bootbox.sh` as the release-shaped artifact prepared in CI via the release workflows.
-- Preserve the source script's single top-level `SCRIPT_VERSION` assignment pattern so CI release stamping with `version-injector` keeps working.
+- Do not edit, regenerate, stage, or commit files under `dist/` during local agent work.
+- `dist/` is CI/release-owned output. GitHub Actions may regenerate and stamp it during build,
+  test, release, or hosting workflows.
+- Make source changes in `bootbox.sh`, `site/`, or `scripts/build-dist.js`; leave `dist/`
+  unchanged unless the user explicitly asks for a local generated-artifact update.
+- Treat `bootbox.sh` as the source entrypoint and `dist/bootbox.sh` as the release-shaped hosted
+  artifact prepared by build and release workflows.
+- Preserve the source script's single top-level `SCRIPT_VERSION` assignment pattern so release
+  stamping with `version-injector` keeps working.
+- Do not run `bun run build` locally unless the user explicitly asks for local generated-output
+  verification. Prefer GitHub Actions for build/release artifact validation.
 
 ## CLI Contract
 
-- Treat the README files under [`examples/`](/Users/pirog/tanaab/bootbox/examples) as executable contract specs consumed by Leia in CI, not just prose examples.
-- When changing help text, option names, hidden flags, version output, failure wording, or debug/status messages, review and update the affected example README assertions in the same change.
 - Keep `--help` as the public CLI contract surface.
-- Keep `--check-core` hidden from `--help`; it is an intentionally undocumented 0/1 readiness probe for Bootbox's built-in Homebrew core only.
-- Keep `--check-core` quiet under normal operation; if its behavior changes, update the CLI contract example explicitly.
+- When changing option names, environment variables, help text, hidden flags, version output,
+  failure wording, debug output, planning output, or status messages, update affected README
+  usage/configuration content and Leia examples in the same change.
+- Any `bootbox.sh` public interface change must check `README.md`, `examples/bootbox-cli-contract`,
+  and the affected mutating examples.
+- Keep `--check-core` hidden from `--help`; it is an intentionally undocumented 0/1 readiness probe
+  for Bootbox's built-in Homebrew core only.
+- Keep `--check-core` quiet under normal operation; if its behavior changes, update the CLI
+  contract example explicitly.
+- Keep planned-action output aligned with actual execution order.
 
 ## Secrets And Logging
 
 - Never print raw 1Password service account credentials in debug, help, or error output.
-- Mask token-bearing values from `--op-token`, `TANAAB_OP_TOKEN`, and `OP_SERVICE_ACCOUNT_TOKEN` when they appear in any diagnostic surface.
-- Preserve the repo's CLI color conventions for status verbs and targets; use the established Tanaab styles rather than ad hoc color choices for action labels such as `running`.
+- Mask token-bearing values from `--op-token`, `TANAAB_OP_TOKEN`, and
+  `OP_SERVICE_ACCOUNT_TOKEN` when they appear in any diagnostic surface.
+- Preserve the repo's CLI color conventions for status verbs and targets; use the established
+  Tanaab styles rather than ad hoc color choices for action labels such as `running`.
 
-## Validation
+## Leia Example Style
 
-- For shell changes, start with the narrowest relevant check such as `shellcheck bootbox.sh` or `bun run lint:shellcheck`.
-- Do not treat local `dist/` regeneration as part of normal validation; if build-artifact verification matters, say it was deferred to CI.
-- Leia example scenarios under `examples/` remain CI-owned unless the user explicitly asks for a local Leia run.
-- Live 1Password-backed SSH key validation remains CI-owned because it depends on the `TANAAB_OP_TESTVAULT` secret on fresh macOS runners.
+- Leia examples under `examples/` are CI-owned executable scenarios. They may mutate GitHub-hosted
+  macOS runners, but should not be treated as routine local validation.
+- Prefer direct command pipelines, command substitutions, and deterministic inline values over
+  writing files just to inspect them later.
+- Do not capture command output into shell variables just to grep it later. Leia failure output must
+  surface useful stdout/stderr in CI; prefer direct commands or `cmd | tee /dev/stderr | grep ...`
+  when an assertion needs both matching and diagnostics.
+- Treat each blank-line-separated Leia block as a separate script. Do not rely on shell variables,
+  functions, or working-directory changes persisting across `should` blocks.
+- Use `TMPDIR` for durable fixtures, unavoidable logs, and helper internals only.
+
+## Validation Policy
+
+- Prefer the narrowest reliable checks for the touched surface.
+- For routine local validation, use `bun run lint`.
+- For shell changes, start with the narrowest relevant check such as `shellcheck bootbox.sh` or
+  `bun run lint:shellcheck`.
+- Run `git diff --check` when whitespace or generated text churn is plausible.
+- Run `bun install` when dependencies are missing before linting, and keep `bun.lock` as a tracked
+  dependency artifact when Bun updates it.
+- Do not run `bootbox.sh`, `dist/bootbox.sh`, or Leia examples as routine local validation unless
+  the user explicitly asks for local execution. Non-mutating help checks are acceptable when a
+  README/development task specifically calls for them.
+- Do not treat local `dist/` regeneration as part of normal validation; if build-artifact
+  verification matters, say it was deferred to CI.
+- Live 1Password-backed SSH key validation remains CI-owned because it depends on the
+  `TANAAB_OP_TESTVAULT` secret on fresh macOS runners.
+
+## Release And Distribution
+
+- Netlify publishes committed `dist/`, but local agents should not update it directly; CI/release
+  workflows own generated `dist/` changes.
+- Release workflows use the Bootbox-style shell-script distribution flow. Keep `dist/bootbox.sh` as
+  the stamped hosted entrypoint.
+- Do not add unrelated package archives or upload behavior unless the release contract explicitly
+  changes.
+- Generated hosting changes should check `scripts/build-dist.js`, `site/`, `dist/`, `netlify.toml`,
+  and release workflow assumptions together.
+
+## `bootbox.sh` Invariants
+
+- Preserve the public `TANAAB_*` namespace unless the task explicitly changes Bootbox's upstream
+  interface.
+- Preserve `--check-core` as a hidden, quiet probe for built-in Homebrew core readiness only.
+- Preserve token masking in debug output and do not reintroduce raw argument logging.
+- Keep repeatable CLI inputs replacing env-sourced lists when any corresponding CLI flag is
+  provided.
+- Treat empty inline repeatable inputs such as `--brewfile=` or `--ssh-key=` as intentional list
+  clearing; do not treat an empty `--target=` as meaningful.
+- Prefer targeted edits to `bootbox.sh`; avoid whole-file rewrites unless the script contract is
+  being intentionally replaced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.0-beta.5 - [May 2, 2026](https://github.com/tanaabased/bootbox/releases/tag/v1.0.0-beta.5)
 
-- Updated Bootbox core to install `1password-cli@beta` for 1Password Environment support. ([#5](https://github.com/tanaabased/bootbox/pull/5), [#4](https://github.com/tanaabased/bootbox/issues/4))
+- Updated `bootbox` core to install `1password-cli@beta` for 1Password Environment support. ([#5](https://github.com/tanaabased/bootbox/pull/5), [#4](https://github.com/tanaabased/bootbox/issues/4))
 
 ## v1.0.0-beta.4 - [March 18, 2026](https://github.com/tanaabased/bootbox/releases/tag/v1.0.0-beta.4)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Bootbox
+# bootbox
 
-Bootbox is a hosted bootstrap script for macOS 26 or newer that turns a fresh box into a usable
+`bootbox` is a hosted bootstrap script for macOS 26 or newer that turns a fresh box into a usable
 base machine. It installs Homebrew, applies one or more Brewfiles, stows one or more dotpackages,
 and can install private SSH keys from a 1Password vault.
 
-Bootbox is meant to be a reusable base script that narrower machine profiles can wrap and extend.
+`bootbox` is meant to be a reusable base script that narrower machine profiles can wrap and extend.
 Examples of that pattern include [pirog/me](https://github.com/pirog/me),
 [tanaabased/agentbox](https://github.com/tanaabased/agentbox), and
 [tanaabased/emori](https://github.com/tanaabased/emori).
@@ -19,14 +19,14 @@ curl -fsSL https://bootbox.tanaab.sh/bootbox.sh | bash
 
 ## Installation
 
-Bootbox is designed to be run directly from the hosted script at
+`bootbox` is designed to be run directly from the hosted script at
 `https://bootbox.tanaab.sh/bootbox.sh`.
 
 - It requires Bash and cURL to start.
 - It supports installing into the default home directory target or a custom `--target`.
 - For 1Password-backed SSH keys, provide a service account token with `--op-token`,
   `BOOTBOX_OP_TOKEN`, or `OP_SERVICE_ACCOUNT_TOKEN`.
-- Bootbox currently installs the beta 1Password CLI cask because downstream machine profiles need
+- `bootbox` currently installs the beta 1Password CLI cask because downstream machine profiles need
   Environment commands such as `op run --environment`. This should return to stable
   `1password-cli` once stable 1Password CLI includes that support.
 - The hosted URL serves the generated `dist/bootbox.sh` entrypoint used for releases.
@@ -34,7 +34,7 @@ Bootbox is designed to be run directly from the hosted script at
 ## Usage
 
 The main flow is: choose a target machine, decide which Brewfiles and dotpackages you want, and then
-run Bootbox once to converge the box into that state. If you have installed the hosted script as a
+run `bootbox` once to converge the box into that state. If you have installed the hosted script as a
 local `bootbox` command, the common flows look like this:
 
 ```sh
@@ -52,7 +52,7 @@ including multi-Brewfile installs, dotpackage installs, and live 1Password SSH k
 
 ## Configuration
 
-Bootbox keeps its configuration surface intentionally small.
+`bootbox` keeps its configuration surface intentionally small.
 
 - `BOOTBOX_BREWFILE`: comma-separated Brewfile paths or URLs
 - `BOOTBOX_DOTPKG`: comma-separated dotpackage paths
@@ -60,7 +60,7 @@ Bootbox keeps its configuration surface intentionally small.
 - `BOOTBOX_OP_TOKEN`: 1Password service account token
 - `BOOTBOX_TARGET`: install target directory
 - `BOOTBOX_FORCE`: enables supported overwrite behavior
-- `BOOTBOX_QUIET`: suppresses Bootbox status output for wrapper callers
+- `BOOTBOX_QUIET`: suppresses `bootbox` status output for wrapper callers
 - `BOOTBOX_NO_SUDO`: disables sudo checks, prompts, and elevation
 - `BOOTBOX_DEBUG`: enables debug logging
 - `NONINTERACTIVE` and `CI`: disable prompts for automated runs
@@ -92,8 +92,8 @@ curl -fsSL https://bootbox.tanaab.sh/bootbox.sh | BOOTBOX_SSH_KEY="my-vault/id_w
 For the complete and current documented CLI surface, prefer `--help`. That output is the fastest
 source of truth for supported public flags, environment variables, and guardrails.
 
-For scripts that only need to know whether Bootbox's built-in Homebrew base is already satisfied,
-there is also a hidden `--check-core` flag. It exits `0` when Homebrew plus Bootbox's core
+For scripts that only need to know whether `bootbox`'s built-in Homebrew base is already satisfied,
+there is also a hidden `--check-core` flag. It exits `0` when Homebrew plus `bootbox`'s core
 packages are already installed, and exits `1` otherwise. It intentionally stays out of `--help`,
 and it does not check Brewfile entries, dotpackages, SSH keys, or target permissions.
 
@@ -106,12 +106,12 @@ fi
 ```
 
 Wrapper scripts that already know sudo is unavailable can pass `--no-sudo` or
-`BOOTBOX_NO_SUDO=1`. In that mode Bootbox does not probe, prompt for, or invoke sudo; requested
+`BOOTBOX_NO_SUDO=1`. In that mode `bootbox` does not probe, prompt for, or invoke sudo; requested
 work must already be writable by the current user.
 
 ## Development
 
-Bootbox uses Bun for its repo-local tooling and publishes a Netlify-ready `dist/` directory.
+`bootbox` uses Bun for its repo-local tooling and publishes a Netlify-ready `dist/` directory.
 
 ```sh
 bun install

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Bootbox keeps its configuration surface intentionally small.
 - `BOOTBOX_TARGET`: install target directory
 - `BOOTBOX_FORCE`: enables supported overwrite behavior
 - `BOOTBOX_QUIET`: suppresses Bootbox status output for wrapper callers
+- `BOOTBOX_NO_SUDO`: disables sudo checks, prompts, and elevation
 - `BOOTBOX_DEBUG`: enables debug logging
 - `NONINTERACTIVE` and `CI`: disable prompts for automated runs
 
@@ -103,6 +104,10 @@ else
   echo "bootbox core is missing dependencies"
 fi
 ```
+
+Wrapper scripts that already know sudo is unavailable can pass `--no-sudo` or
+`BOOTBOX_NO_SUDO=1`. In that mode Bootbox does not probe, prompt for, or invoke sudo; requested
+work must already be writable by the current user.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Bootbox is designed to be run directly from the hosted script at
 - It requires Bash and cURL to start.
 - It supports installing into the default home directory target or a custom `--target`.
 - For 1Password-backed SSH keys, provide a service account token with `--op-token`,
-  `TANAAB_OP_TOKEN`, or `OP_SERVICE_ACCOUNT_TOKEN`.
+  `BOOTBOX_OP_TOKEN`, or `OP_SERVICE_ACCOUNT_TOKEN`.
 - Bootbox currently installs the beta 1Password CLI cask because downstream machine profiles need
   Environment commands such as `op run --environment`. This should return to stable
   `1password-cli` once stable 1Password CLI includes that support.
@@ -40,7 +40,7 @@ local `bootbox` command, the common flows look like this:
 ```sh
 bootbox --brewfile Brewfile.work --target "$HOME"
 bootbox --dotpkg dotpkgs/git --dotpkg dotpkgs/zsh --target "$HOME"
-bootbox --ssh-key "my-vault/id_work" --op-token "$TANAAB_OP_TOKEN"
+bootbox --ssh-key "my-vault/id_work" --op-token "$BOOTBOX_OP_TOKEN"
 ```
 
 If you are working from a local checkout instead, replace `bootbox` with `./bootbox.sh`.
@@ -54,14 +54,14 @@ including multi-Brewfile installs, dotpackage installs, and live 1Password SSH k
 
 Bootbox keeps its configuration surface intentionally small.
 
-- `TANAAB_BREWFILE`: comma-separated Brewfile paths or URLs
-- `TANAAB_DOTPKG`: comma-separated dotpackage paths
-- `TANAAB_SSH_KEY`: comma-separated `vault/item[:filename]` SSH key specs
-- `TANAAB_OP_TOKEN`: 1Password service account token
-- `TANAAB_TARGET`: install target directory
-- `TANAAB_FORCE`: enables supported overwrite behavior
-- `TANAAB_QUIET`: suppresses Bootbox status output for wrapper callers
-- `TANAAB_DEBUG`: enables debug logging
+- `BOOTBOX_BREWFILE`: comma-separated Brewfile paths or URLs
+- `BOOTBOX_DOTPKG`: comma-separated dotpackage paths
+- `BOOTBOX_SSH_KEY`: comma-separated `vault/item[:filename]` SSH key specs
+- `BOOTBOX_OP_TOKEN`: 1Password service account token
+- `BOOTBOX_TARGET`: install target directory
+- `BOOTBOX_FORCE`: enables supported overwrite behavior
+- `BOOTBOX_QUIET`: suppresses Bootbox status output for wrapper callers
+- `BOOTBOX_DEBUG`: enables debug logging
 - `NONINTERACTIVE` and `CI`: disable prompts for automated runs
 
 ## Advanced
@@ -76,16 +76,16 @@ chmod +x "$HOME/.local/bin/bootbox"
 
 bootbox --help
 bootbox --brewfile Brewfile.work --dotpkg dotpkgs/git --target "$HOME"
-bootbox --ssh-key "my-vault/id_work:id_ed25519_work" --op-token "$TANAAB_OP_TOKEN"
+bootbox --ssh-key "my-vault/id_work:id_ed25519_work" --op-token "$BOOTBOX_OP_TOKEN"
 ```
 
 If you do not want to install a local command first, you can also set environment variables inline
 and pipe the hosted script straight into Bash.
 
 ```sh
-curl -fsSL https://bootbox.tanaab.sh/bootbox.sh | TANAAB_BREWFILE="Brewfile.work" TANAAB_TARGET="$HOME" bash
-curl -fsSL https://bootbox.tanaab.sh/bootbox.sh | TANAAB_DOTPKG="dotpkgs/git,dotpkgs/zsh" TANAAB_TARGET="$HOME" bash
-curl -fsSL https://bootbox.tanaab.sh/bootbox.sh | TANAAB_SSH_KEY="my-vault/id_work:id_work" TANAAB_OP_TOKEN="$TANAAB_OP_TOKEN" bash
+curl -fsSL https://bootbox.tanaab.sh/bootbox.sh | BOOTBOX_BREWFILE="Brewfile.work" BOOTBOX_TARGET="$HOME" bash
+curl -fsSL https://bootbox.tanaab.sh/bootbox.sh | BOOTBOX_DOTPKG="dotpkgs/git,dotpkgs/zsh" BOOTBOX_TARGET="$HOME" bash
+curl -fsSL https://bootbox.tanaab.sh/bootbox.sh | BOOTBOX_SSH_KEY="my-vault/id_work:id_work" BOOTBOX_OP_TOKEN="$BOOTBOX_OP_TOKEN" bash
 ```
 
 For the complete and current documented CLI surface, prefer `--help`. That output is the fastest
@@ -116,7 +116,7 @@ bun run build
 
 The example suite is intentionally not exposed as a local package script. Leia examples are run in
 GitHub Actions on fresh macOS runners because they can mutate machine state, install Homebrew
-packages, and access the `TANAAB_OP_TESTVAULT` CI secret for the live SSH-key example.
+packages, and access the `BOOTBOX_OP_TESTVAULT` CI environment value for the live SSH-key example.
 
 ## Issues, Questions and Support
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Bootbox keeps its configuration surface intentionally small.
 - `TANAAB_OP_TOKEN`: 1Password service account token
 - `TANAAB_TARGET`: install target directory
 - `TANAAB_FORCE`: enables supported overwrite behavior
+- `TANAAB_QUIET`: suppresses Bootbox status output for wrapper callers
 - `TANAAB_DEBUG`: enables debug logging
 - `NONINTERACTIVE` and `CI`: disable prompts for automated runs
 

--- a/bootbox.sh
+++ b/bootbox.sh
@@ -2007,8 +2007,8 @@ refresh_permission_dirs
 
 if no_sudo_enabled && [[ "${BREW_NEEDS_INSTALL:-0}" == "1" ]]; then
   abort_multi "$(cat <<EOABORT
-Homebrew is missing and Bootbox is running with ${tty_bold}--no-sudo${tty_reset}.
-install Homebrew from a privileged machine-prep layer first, then rerun Bootbox without requiring sudo.
+Homebrew is missing and bootbox is running with ${tty_bold}--no-sudo${tty_reset}.
+install Homebrew from a privileged machine-prep layer first, then rerun bootbox without requiring sudo.
 for more information on advanced usage rerun with --help or check out: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
 EOABORT
 )"
@@ -2016,7 +2016,7 @@ fi
 
 if needs_sudo && no_sudo_enabled; then
   abort_multi "$(cat <<EOABORT
-Bootbox is running with ${tty_bold}--no-sudo${tty_reset}, but ${tty_bold}${USER}${tty_reset} cannot write to ${tty_red}${TARGET}${tty_reset} or the expected Homebrew location ${tty_red}${HOMEBREW_PREFIX}${tty_reset}.
+bootbox is running with ${tty_bold}--no-sudo${tty_reset}, but ${tty_bold}${USER}${tty_reset} cannot write to ${tty_red}${TARGET}${tty_reset} or the expected Homebrew location ${tty_red}${HOMEBREW_PREFIX}${tty_reset}.
 prepare writable Homebrew and target paths in the wrapper or machine-prep layer, or use --target to install into a directory ${tty_bold}${USER}${tty_reset} can write to.
 for more information on advanced usage rerun with --help or check out: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
 EOABORT

--- a/bootbox.sh
+++ b/bootbox.sh
@@ -135,34 +135,55 @@ value_enabled() {
   esac
 }
 
+env_value() {
+  local preferred_name="$1"
+  local legacy_name="$2"
+  local fallback="${3-}"
+  local preferred_value="${!preferred_name-}"
+  local legacy_value="${!legacy_name-}"
+
+  if [[ -n "${preferred_value}" ]]; then
+    printf "%s" "${preferred_value}"
+  elif [[ -n "${legacy_value}" ]]; then
+    printf "%s" "${legacy_value}"
+  else
+    printf "%s" "${fallback}"
+  fi
+}
+
+env_list_value() {
+  local preferred_name="$1"
+  local preferred_plural_name="$2"
+  local legacy_name="$3"
+  local legacy_plural_name="$4"
+  local primary
+  local secondary
+
+  primary="${!preferred_name-}"
+  secondary="${!preferred_plural_name-}"
+  if [[ -n "${primary}" || -n "${secondary}" ]]; then
+    printf "%s%s%s" "${primary}" "${primary:+${secondary:+,}}" "${secondary}"
+    return 0
+  fi
+
+  primary="${!legacy_name-}"
+  secondary="${!legacy_plural_name-}"
+  printf "%s%s%s" "${primary}" "${primary:+${secondary:+,}}" "${secondary}"
+}
+
 # Set cheap defaults needed by usage/arg parsing first so --help/--version stay fast.
 #
 # RUNNER_DEBUG is used here so we can get good debug output when toggled in GitHub Actions
 # see https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/
-DEBUG="${TANAAB_DEBUG:-${DEBUG:-${RUNNER_DEBUG:-}}}"
-FORCE="${TANAAB_FORCE:-}"
-QUIET="${TANAAB_QUIET:-}"
+DEBUG="$(env_value BOOTBOX_DEBUG TANAAB_DEBUG "${DEBUG:-${RUNNER_DEBUG:-}}")"
+FORCE="$(env_value BOOTBOX_FORCE TANAAB_FORCE)"
+QUIET="$(env_value BOOTBOX_QUIET TANAAB_QUIET)"
 CHECK_CORE=""
-TARGET="${TANAAB_TARGET:-$HOME}"
-BREWFILES_CSV="${TANAAB_BREWFILE:-}"
-DOTPKGS_CSV="${TANAAB_DOTPKG:-}"
-OP_TOKEN="${TANAAB_OP_TOKEN:-${OP_SERVICE_ACCOUNT_TOKEN:-}}"
-SSH_KEYS_CSV="${TANAAB_SSH_KEY:-}"
-
-# accommodate TANAAB_BREWFILES as well
-if [[ -n "${TANAAB_BREWFILES:-}" ]]; then
-  BREWFILES_CSV="${BREWFILES_CSV}${BREWFILES_CSV:+,}${TANAAB_BREWFILES}"
-fi
-
-# accommodate TANAAB_DOTPKGS as well
-if [[ -n "${TANAAB_DOTPKGS:-}" ]]; then
-  DOTPKGS_CSV="${DOTPKGS_CSV}${DOTPKGS_CSV:+,}${TANAAB_DOTPKGS}"
-fi
-
-# accommodate TANAAB_SSH_KEYS as well
-if [[ -n "${TANAAB_SSH_KEYS:-}" ]]; then
-  SSH_KEYS_CSV="${SSH_KEYS_CSV}${SSH_KEYS_CSV:+,}${TANAAB_SSH_KEYS}"
-fi
+TARGET="$(env_value BOOTBOX_TARGET TANAAB_TARGET "$HOME")"
+BREWFILES_CSV="$(env_list_value BOOTBOX_BREWFILE BOOTBOX_BREWFILES TANAAB_BREWFILE TANAAB_BREWFILES)"
+DOTPKGS_CSV="$(env_list_value BOOTBOX_DOTPKG BOOTBOX_DOTPKGS TANAAB_DOTPKG TANAAB_DOTPKGS)"
+OP_TOKEN="$(env_value BOOTBOX_OP_TOKEN TANAAB_OP_TOKEN "${OP_SERVICE_ACCOUNT_TOKEN:-}")"
+SSH_KEYS_CSV="$(env_list_value BOOTBOX_SSH_KEY BOOTBOX_SSH_KEYS TANAAB_SSH_KEY TANAAB_SSH_KEYS)"
 
 # collect them all togethers with fallback if still empty
 if [[ -z "${BREWFILES_CSV}" ]] && [[ -f "./Brewfile" ]]; then
@@ -333,7 +354,7 @@ usage() {
   fi
 
   cat <<EOS
-Usage: ${tty_dim}[NONINTERACTIVE=1] [CI=1] [TANAAB_*...]${tty_reset} ${tty_bold}${SCRIPT_NAME}${tty_reset} ${tty_dim}[options]${tty_reset}
+Usage: ${tty_dim}[NONINTERACTIVE=1] [CI=1] [BOOTBOX_*...]${tty_reset} ${tty_bold}${SCRIPT_NAME}${tty_reset} ${tty_dim}[options]${tty_reset}
 
 ${tty_tp}Options:${tty_reset}
   --brewfile       installs brewfiles from local paths or URLs ${tty_dim}[default: ${brewfiles_display}]${tty_reset}
@@ -349,14 +370,14 @@ ${tty_tp}Options:${tty_reset}
   -y, --yes        runs with all defaults and no prompts, sets NONINTERACTIVE=1
 
 ${tty_tp}Environment Variables:${tty_reset}
-  TANAAB_BREWFILE  same as --brewfile
-  TANAAB_DOTPKG    same as --dotpkg
-  TANAAB_SSH_KEY   same as --ssh-key
-  TANAAB_OP_TOKEN  same as --op-token; falls back to OP_SERVICE_ACCOUNT_TOKEN
-  TANAAB_TARGET    same as --target
-  TANAAB_FORCE     same as --force
-  TANAAB_QUIET     same as --quiet
-  TANAAB_DEBUG     same as --debug
+  BOOTBOX_BREWFILE same as --brewfile
+  BOOTBOX_DOTPKG   same as --dotpkg
+  BOOTBOX_SSH_KEY  same as --ssh-key
+  BOOTBOX_OP_TOKEN same as --op-token; falls back to OP_SERVICE_ACCOUNT_TOKEN
+  BOOTBOX_TARGET   same as --target
+  BOOTBOX_FORCE    same as --force
+  BOOTBOX_QUIET    same as --quiet
+  BOOTBOX_DEBUG    same as --debug
   NONINTERACTIVE   same as --yes
   CI               runs in CI mode and disables prompts
 EOS
@@ -783,7 +804,7 @@ default_homebrew_prefix() {
 }
 
 # core packages that should be present regardless of any user-provided Brewfile
-declare -a TANAAB_CORE_BREW_PACKAGES=(
+declare -a BOOTBOX_CORE_BREW_PACKAGES=(
   "formula|git|git"
   "cask|1password-cli@beta|op"
   "formula|curl|curl"
@@ -793,17 +814,17 @@ declare -a TANAAB_CORE_BREW_PACKAGES=(
 )
 
 # GET THE LTF right away once we know we are not exiting through usage/version.
-TANAAB_TMPFILE="$(mktemp -t tanaab.XXXXXX)"
+BOOTBOX_TMPFILE="$(mktemp -t bootbox.XXXXXX)"
 
 # derive the rest of the runtime defaults after argument parsing
 detect_arch
 detect_os
 
-ARCH="${TANAAB_ARCH:-"$DETECTED_ARCH"}"
-OS="${TANAAB_OS:-"$DETECTED_OS"}"
+ARCH="$(env_value BOOTBOX_ARCH TANAAB_ARCH "$DETECTED_ARCH")"
+OS="$(env_value BOOTBOX_OS TANAAB_OS "$DETECTED_OS")"
 HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-"$(default_homebrew_prefix "$ARCH")"}"
 HOMEBREW_INSTALLER_URL="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
-TANAAB_TMPDIR=$(get_abs_dir "$TANAAB_TMPFILE")
+BOOTBOX_TMPDIR=$(get_abs_dir "$BOOTBOX_TMPFILE")
 
 # USER isn't always set so provide a fall back for the installer and subprocesses.
 if [[ -z "${USER-}" ]]; then
@@ -911,8 +932,8 @@ debug raw HOMEBREW_PREFIX="$HOMEBREW_PREFIX"
 debug raw TARGET="$TARGET"
 debug raw OS="$OS"
 debug raw USER="$USER"
-debug raw TMPFILE="$TANAAB_TMPFILE"
-debug raw TMPDIR="$TANAAB_TMPDIR"
+debug raw TMPFILE="$BOOTBOX_TMPFILE"
+debug raw TMPDIR="$BOOTBOX_TMPDIR"
 
 #######################################################################  tool-verification
 
@@ -1132,7 +1153,7 @@ plan_homebrew() {
 }
 
 install_homebrew() {
-  local installer="${TANAAB_TMPDIR}/homebrew-install.sh"
+  local installer="${BOOTBOX_TMPDIR}/homebrew-install.sh"
 
   log "${tty_tp}installing${tty_reset} ${tty_ts}homebrew${tty_reset} ${tty_dim}because it is not installed${tty_reset}"
   execute "${CURL}" \
@@ -1171,7 +1192,7 @@ plan_core_homebrew_packages() {
   CORE_BREW_CASK_DISPLAY_TO_INSTALL=()
   CORE_BREW_DISPLAY_TO_INSTALL=()
 
-  for entry in "${TANAAB_CORE_BREW_PACKAGES[@]}"; do
+  for entry in "${BOOTBOX_CORE_BREW_PACKAGES[@]}"; do
     IFS='|' read -r type package display <<< "${entry}"
 
     if [[ "${BREW_NEEDS_INSTALL:-0}" == "1" ]]; then
@@ -1226,7 +1247,7 @@ fetch_brewfile_url() {
   local url="$1"
   local destination
 
-  destination="$(mktemp "${TANAAB_TMPDIR}/brewfile-url.XXXXXX")"
+  destination="$(mktemp "${BOOTBOX_TMPDIR}/brewfile-url.XXXXXX")"
   debug "fetching brewfile ${url} to ${destination}"
 
   if ! "${CURL}" \
@@ -1278,7 +1299,7 @@ prepare_effective_brewfile() {
     return 0
   fi
 
-  effective_brewfile="$(mktemp "${TANAAB_TMPDIR}/brewfile-effective.XXXXXX")"
+  effective_brewfile="$(mktemp "${BOOTBOX_TMPDIR}/brewfile-effective.XXXXXX")"
   : > "${effective_brewfile}"
 
   for source_brewfile in "${RESOLVED_BREWFILES[@]}"; do
@@ -1450,7 +1471,7 @@ plan_ssh_keys() {
   if [[ -z "${OP_TOKEN:-}" ]]; then
     abort_multi "$(cat <<EOABORT
 ssh key installation requires a 1password service account token.
-set TANAAB_OP_TOKEN or OP_SERVICE_ACCOUNT_TOKEN, or pass --op-token.
+set BOOTBOX_OP_TOKEN or OP_SERVICE_ACCOUNT_TOKEN, or pass --op-token.
 EOABORT
 )"
   fi
@@ -1537,7 +1558,7 @@ EOABORT
       log "${tty_tp}installing${tty_reset} ssh key ${tty_ts}${filename}${tty_reset} ${tty_dim}into${tty_reset} ${tty_ts}${ssh_dir}${tty_reset}"
     fi
 
-    key_tmpfile="$(mktemp "${TANAAB_TMPDIR}/ssh-key.XXXXXX")"
+    key_tmpfile="$(mktemp "${BOOTBOX_TMPDIR}/ssh-key.XXXXXX")"
     op_read_ssh_key_to_file "${ssh_key}" "${key_tmpfile}"
     auto_mv "${key_tmpfile}" "${destination_path}"
     auto_chmod 600 "${destination_path}"
@@ -1900,7 +1921,7 @@ debug "using the cURL at ${CURL}"
 ####################################################################### version validation
 
 needs_sudo() {
-  if [[ ! -w "$HOMEBREW_PERM_DIR" ]] || [[ ! -w "$PERM_DIR" ]] || [[ ! -w "$TANAAB_TMPDIR" ]]; then
+  if [[ ! -w "$HOMEBREW_PERM_DIR" ]] || [[ ! -w "$PERM_DIR" ]] || [[ ! -w "$BOOTBOX_TMPDIR" ]]; then
     return 0;
   else
     return 1;

--- a/bootbox.sh
+++ b/bootbox.sh
@@ -178,6 +178,7 @@ env_list_value() {
 DEBUG="$(env_value BOOTBOX_DEBUG TANAAB_DEBUG "${DEBUG:-${RUNNER_DEBUG:-}}")"
 FORCE="$(env_value BOOTBOX_FORCE TANAAB_FORCE)"
 QUIET="$(env_value BOOTBOX_QUIET TANAAB_QUIET)"
+NO_SUDO="${BOOTBOX_NO_SUDO:-}"
 CHECK_CORE=""
 TARGET="$(env_value BOOTBOX_TARGET TANAAB_TARGET "$HOME")"
 BREWFILES_CSV="$(env_list_value BOOTBOX_BREWFILE BOOTBOX_BREWFILES TANAAB_BREWFILE TANAAB_BREWFILES)"
@@ -331,6 +332,7 @@ usage() {
   local debug_display="off"
   local dotpkgs_display
   local force_display="off"
+  local no_sudo_display="off"
   local quiet_display="off"
   local ssh_keys_display
 
@@ -353,6 +355,10 @@ usage() {
     quiet_display="on"
   fi
 
+  if value_enabled "${NO_SUDO:-}"; then
+    no_sudo_display="on"
+  fi
+
   cat <<EOS
 Usage: ${tty_dim}[NONINTERACTIVE=1] [CI=1] [BOOTBOX_*...]${tty_reset} ${tty_bold}${SCRIPT_NAME}${tty_reset} ${tty_dim}[options]${tty_reset}
 
@@ -365,6 +371,7 @@ ${tty_tp}Options:${tty_reset}
   --version        shows version of this script
   --debug          shows debug messages ${tty_dim}[default: ${debug_display}]${tty_reset}
   --quiet          suppresses bootbox status output ${tty_dim}[default: ${quiet_display}]${tty_reset}
+  --no-sudo        disables sudo checks, prompts, and elevation ${tty_dim}[default: ${no_sudo_display}]${tty_reset}
   --force          forces supported overwrite operations ${tty_dim}[default: ${force_display}]${tty_reset}
   -h, --help       displays this help message
   -y, --yes        runs with all defaults and no prompts, sets NONINTERACTIVE=1
@@ -377,6 +384,7 @@ ${tty_tp}Environment Variables:${tty_reset}
   BOOTBOX_TARGET   same as --target
   BOOTBOX_FORCE    same as --force
   BOOTBOX_QUIET    same as --quiet
+  BOOTBOX_NO_SUDO  same as --no-sudo
   BOOTBOX_DEBUG    same as --debug
   NONINTERACTIVE   same as --yes
   CI               runs in CI mode and disables prompts
@@ -486,6 +494,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --quiet)
       QUIET=1
+      shift
+      ;;
+    --no-sudo)
+      NO_SUDO=1
       shift
       ;;
     --force)
@@ -861,6 +873,14 @@ quiet_enabled() {
   value_enabled "${QUIET:-}"
 }
 
+no_sudo_enabled() {
+  value_enabled "${NO_SUDO:-}"
+}
+
+sudo_enabled() {
+  ! no_sudo_enabled
+}
+
 check_core_mode() {
   [[ "${CHECK_CORE:-0}" == "1" ]]
 }
@@ -1073,6 +1093,11 @@ find_homebrew() {
 have_sudo_access() {
   local GROUPS_CMD
   local -a SUDO=("/usr/bin/sudo")
+
+  if no_sudo_enabled; then
+    HAVE_SUDO_ACCESS="1"
+    return 1
+  fi
 
   GROUPS_CMD="$(which groups)"
 
@@ -1980,6 +2005,24 @@ refresh_permission_dirs
 
 # @NOTE: in order to do what we want here does the user actually need to be a sudoer?
 
+if no_sudo_enabled && [[ "${BREW_NEEDS_INSTALL:-0}" == "1" ]]; then
+  abort_multi "$(cat <<EOABORT
+Homebrew is missing and Bootbox is running with ${tty_bold}--no-sudo${tty_reset}.
+install Homebrew from a privileged machine-prep layer first, then rerun Bootbox without requiring sudo.
+for more information on advanced usage rerun with --help or check out: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
+EOABORT
+)"
+fi
+
+if needs_sudo && no_sudo_enabled; then
+  abort_multi "$(cat <<EOABORT
+Bootbox is running with ${tty_bold}--no-sudo${tty_reset}, but ${tty_bold}${USER}${tty_reset} cannot write to ${tty_red}${TARGET}${tty_reset} or the expected Homebrew location ${tty_red}${HOMEBREW_PREFIX}${tty_reset}.
+prepare writable Homebrew and target paths in the wrapper or machine-prep layer, or use --target to install into a directory ${tty_bold}${USER}${tty_reset} can write to.
+for more information on advanced usage rerun with --help or check out: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
+EOABORT
+)"
+fi
+
 if needs_sudo && ! have_sudo_access; then
   abort_multi "$(cat <<EOABORT
 ${tty_bold}${USER}${tty_reset} cannot write to ${tty_red}${TARGET}${tty_reset} or the expected Homebrew location ${tty_red}${HOMEBREW_PREFIX}${tty_reset} and is not a ${tty_bold}sudo${tty_reset} user.
@@ -2030,7 +2073,7 @@ execute() {
 
 execute_sudo() {
   local -a args=("$@")
-  if [[ "${EUID:-${UID}}" != "0" ]] && have_sudo_access; then
+  if sudo_enabled && [[ "${EUID:-${UID}}" != "0" ]] && have_sudo_access; then
     if [[ -n "${SUDO_ASKPASS-}" ]]; then
       args=("-A" "${args[@]}")
     fi
@@ -2061,7 +2104,7 @@ auto_mkdirp() {
   local perm_dir
   perm_dir="$(find_first_existing_parent "$dir")"
 
-  if have_sudo_access && [[ ! -w "$perm_dir" ]]; then
+  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_dir" ]]; then
     execute_sudo mkdir -p "$dir"
   else
     execute mkdir -p "$dir"
@@ -2077,7 +2120,7 @@ auto_mv() {
   perm_source="$(find_first_existing_parent "$source")"
   perm_dest="$(find_first_existing_parent "$dest")"
 
-  if have_sudo_access && [[ ! -w "$perm_source" ||  ! -w "$perm_dest" ]]; then
+  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_source" ||  ! -w "$perm_dest" ]]; then
     execute_sudo mv -f "$source" "$dest"
   else
     execute mv -f "$source" "$dest"
@@ -2091,7 +2134,7 @@ auto_cp_follow() {
   local perm_dest
   perm_dest="$(find_first_existing_parent "$dest")"
 
-  if have_sudo_access && [[ ! -w "$perm_dest" ]]; then
+  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_dest" ]]; then
     execute_sudo cp -RL "$source" "$dest"
   else
     execute cp -RL "$source" "$dest"
@@ -2104,7 +2147,7 @@ auto_rm() {
   local perm_dir
   perm_dir="$(find_first_existing_parent "$path")"
 
-  if have_sudo_access && [[ ! -w "$perm_dir" ]]; then
+  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_dir" ]]; then
     execute_sudo rm -f "$path"
   else
     execute rm -f "$path"
@@ -2118,7 +2161,7 @@ auto_chmod() {
   local perm_dir
   perm_dir="$(find_first_existing_parent "$path")"
 
-  if have_sudo_access && [[ ! -w "$perm_dir" ]]; then
+  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_dir" ]]; then
     execute_sudo chmod "${mode}" "$path"
   else
     execute chmod "${mode}" "$path"
@@ -2126,7 +2169,7 @@ auto_chmod() {
 }
 
 # Invalidate sudo timestamp before exiting (if it wasn't active before).
-if [[ -x /usr/bin/sudo ]] && ! /usr/bin/sudo -n -v 2>/dev/null; then
+if sudo_enabled && [[ -x /usr/bin/sudo ]] && ! /usr/bin/sudo -n -v 2>/dev/null; then
   trap '/usr/bin/sudo -k' EXIT
 fi
 
@@ -2141,7 +2184,7 @@ if [[ -z "${NONINTERACTIVE-}" ]] && have_planned_actions; then
 fi
 
 # flag for password here if needed
-if needs_sudo; then
+if sudo_enabled && needs_sudo; then
   log "please enter ${tty_bold}sudo${tty_reset} password:"
   execute_sudo true
 fi

--- a/bootbox.sh
+++ b/bootbox.sh
@@ -141,6 +141,7 @@ value_enabled() {
 # see https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/
 DEBUG="${TANAAB_DEBUG:-${DEBUG:-${RUNNER_DEBUG:-}}}"
 FORCE="${TANAAB_FORCE:-}"
+QUIET="${TANAAB_QUIET:-}"
 CHECK_CORE=""
 TARGET="${TANAAB_TARGET:-$HOME}"
 BREWFILES_CSV="${TANAAB_BREWFILE:-}"
@@ -309,6 +310,7 @@ usage() {
   local debug_display="off"
   local dotpkgs_display
   local force_display="off"
+  local quiet_display="off"
   local ssh_keys_display
 
   brewfiles_display="$(array_join "," BREWFILES)"
@@ -326,6 +328,10 @@ usage() {
     force_display="on"
   fi
 
+  if value_enabled "${QUIET:-}"; then
+    quiet_display="on"
+  fi
+
   cat <<EOS
 Usage: ${tty_dim}[NONINTERACTIVE=1] [CI=1] [TANAAB_*...]${tty_reset} ${tty_bold}${SCRIPT_NAME}${tty_reset} ${tty_dim}[options]${tty_reset}
 
@@ -337,6 +343,7 @@ ${tty_tp}Options:${tty_reset}
   --target         installs dotpkgs and identities relative to here ${tty_dim}[default: ${TARGET}]${tty_reset}
   --version        shows version of this script
   --debug          shows debug messages ${tty_dim}[default: ${debug_display}]${tty_reset}
+  --quiet          suppresses bootbox status output ${tty_dim}[default: ${quiet_display}]${tty_reset}
   --force          forces supported overwrite operations ${tty_dim}[default: ${force_display}]${tty_reset}
   -h, --help       displays this help message
   -y, --yes        runs with all defaults and no prompts, sets NONINTERACTIVE=1
@@ -348,6 +355,7 @@ ${tty_tp}Environment Variables:${tty_reset}
   TANAAB_OP_TOKEN  same as --op-token; falls back to OP_SERVICE_ACCOUNT_TOKEN
   TANAAB_TARGET    same as --target
   TANAAB_FORCE     same as --force
+  TANAAB_QUIET     same as --quiet
   TANAAB_DEBUG     same as --debug
   NONINTERACTIVE   same as --yes
   CI               runs in CI mode and disables prompts
@@ -453,6 +461,10 @@ while [[ $# -gt 0 ]]; do
 
     --debug)
       DEBUG=1
+      shift
+      ;;
+    --quiet)
+      QUIET=1
       shift
       ;;
     --force)
@@ -824,6 +836,10 @@ force_enabled() {
   value_enabled "${FORCE:-}"
 }
 
+quiet_enabled() {
+  value_enabled "${QUIET:-}"
+}
+
 check_core_mode() {
   [[ "${CHECK_CORE:-0}" == "1" ]]
 }
@@ -849,6 +865,10 @@ debug_multi() {
 }
 
 log() {
+  if quiet_enabled; then
+    return 0
+  fi
+
   printf "%s\n" "$(shell_join "$@")"
 }
 

--- a/bootbox.sh
+++ b/bootbox.sh
@@ -29,7 +29,7 @@ MACOS_OLDEST_SUPPORTED="26.0"
 REQUIRED_CURL_VERSION="7.41.0"
 
 abort() {
-  printf "%s\n" "$@" >&2
+  printf "error: %s\n" "$@" >&2
   exit 1
 }
 
@@ -37,12 +37,12 @@ abort() {
 # Single brackets are needed here for POSIX compatibility
 # shellcheck disable=SC2292
 if [ -z "${BASH_VERSION:-}" ]; then
-  abort "Bash is required to interpret this script."
+  abort "bash is required to interpret this script."
 fi
 
 # Check if script is run with force-interactive mode in CI
 if [[ -n "${CI-}" && -n "${INTERACTIVE-}" ]]; then
-  abort "Cannot run force-interactive mode in CI."
+  abort "cannot run force-interactive mode in CI."
 fi
 
 # Check if both `INTERACTIVE` and `NONINTERACTIVE` are set
@@ -54,7 +54,7 @@ fi
 
 # Check if script is run in POSIX mode
 if [[ -n "${POSIXLY_CORRECT+1}" ]]; then
-  abort 'Bash must not run in POSIX mode. Please unset POSIXLY_CORRECT and try again.'
+  abort 'bash must not run in POSIX mode. please unset POSIXLY_CORRECT and try again.'
 fi
 
 if [[ -t 1 ]]; then
@@ -80,7 +80,7 @@ tty_tp="$(tty_escape '38;2;0;200;138')"    # #00c88a
 tty_ts="$(tty_escape '38;2;219;39;119')"   # #db2777
 
 # Keep a single top-level assignment so release automation can stamp the entrypoint in place.
-SCRIPT_VERSION="${SCRIPT_VERSION:-$(git describe --tags --always --abbrev=1 2>/dev/null || printf '%s' '0.0.0')}"
+SCRIPT_VERSION="${SCRIPT_VERSION:-$(git describe --tags --always --abbrev=1 2>/dev/null || printf '%s' '0.0.0-unreleased')}"
 SCRIPT_NAME_SOURCE="${BASH_SOURCE[0]:-${0}}"
 SCRIPT_NAME="${SCRIPT_NAME_SOURCE##*/}"
 
@@ -124,6 +124,17 @@ op_token_for_display() {
   fi
 }
 
+value_enabled() {
+  case "${1:-}" in
+    '' | 0 | false | FALSE | False | no | NO | No | off | OFF | Off)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
 # Set cheap defaults needed by usage/arg parsing first so --help/--version stay fast.
 #
 # RUNNER_DEBUG is used here so we can get good debug output when toggled in GitHub Actions
@@ -156,10 +167,6 @@ fi
 if [[ -z "${BREWFILES_CSV}" ]] && [[ -f "./Brewfile" ]]; then
   BREWFILES_CSV="./Brewfile"
 fi
-
-BREWFILES_CSV_DISPLAY="${BREWFILES_CSV:-none}"
-DOTPKGS_CSV_DISPLAY="${DOTPKGS_CSV:-none}"
-SSH_KEYS_CSV_DISPLAY="${SSH_KEYS_CSV:-none}"
 
 trim_whitespace() {
   local value="$1"
@@ -298,30 +305,52 @@ for arg in "$@"; do
 done
 
 usage() {
+  local brewfiles_display
+  local debug_display="off"
+  local dotpkgs_display
+  local force_display="off"
+  local ssh_keys_display
+
+  brewfiles_display="$(array_join "," BREWFILES)"
+  brewfiles_display="${brewfiles_display:-none}"
+  dotpkgs_display="$(array_join "," DOTPKGS)"
+  dotpkgs_display="${dotpkgs_display:-none}"
+  ssh_keys_display="$(array_join "," SSH_KEYS)"
+  ssh_keys_display="${ssh_keys_display:-none}"
+
+  if value_enabled "${DEBUG:-}"; then
+    debug_display="on"
+  fi
+
+  if value_enabled "${FORCE:-}"; then
+    force_display="on"
+  fi
+
   cat <<EOS
-Usage: ${tty_dim}[NONINTERACTIVE=1] [CI=1]${tty_reset} ${tty_bold}${SCRIPT_NAME}${tty_reset} ${tty_dim}[options]${tty_reset}
+Usage: ${tty_dim}[NONINTERACTIVE=1] [CI=1] [TANAAB_*...]${tty_reset} ${tty_bold}${SCRIPT_NAME}${tty_reset} ${tty_dim}[options]${tty_reset}
 
 ${tty_tp}Options:${tty_reset}
-  --brewfile       installs brewfiles from local paths or URLs ${tty_dim}[default: ${BREWFILES_CSV_DISPLAY}]${tty_reset}
-  --dotpkg         stows dot packages into target ${tty_dim}[default: ${DOTPKGS_CSV_DISPLAY}]${tty_reset}
-  --ssh-key        installs 1password ssh keys into target .ssh as vault/item[:filename] ${tty_dim}[default: ${SSH_KEYS_CSV_DISPLAY}]${tty_reset}
+  --brewfile       installs brewfiles from local paths or URLs ${tty_dim}[default: ${brewfiles_display}]${tty_reset}
+  --dotpkg         stows dot packages into target ${tty_dim}[default: ${dotpkgs_display}]${tty_reset}
+  --ssh-key        installs 1password ssh keys into target .ssh as vault/item[:filename] ${tty_dim}[default: ${ssh_keys_display}]${tty_reset}
   --op-token       auths with 1password service account token ${tty_dim}[default: $(op_token_for_display)]${tty_reset}
   --target         installs dotpkgs and identities relative to here ${tty_dim}[default: ${TARGET}]${tty_reset}
   --version        shows version of this script
-  --debug          shows debug messages
+  --debug          shows debug messages ${tty_dim}[default: ${debug_display}]${tty_reset}
+  --force          forces supported overwrite operations ${tty_dim}[default: ${force_display}]${tty_reset}
   -h, --help       displays this help message
   -y, --yes        runs with all defaults and no prompts, sets NONINTERACTIVE=1
 
 ${tty_tp}Environment Variables:${tty_reset}
-  TANAAB_BREWFILE  comma-separated list of brewfile paths or URLs to install
-  TANAAB_DOTPKG    comma-separated list of stow package paths to install
-  TANAAB_SSH_KEY   comma-separated list of 1password ssh keys as vault/item[:filename]
-  TANAAB_OP_TOKEN  1password service account token; falls back to OP_SERVICE_ACCOUNT_TOKEN
-  TANAAB_TARGET    target directory for dotpkgs and identities
-  TANAAB_FORCE     set to a truthy value to force supported operations
-  TANAAB_DEBUG     set to a truthy value to show debug messages
-  NONINTERACTIVE   installs without prompting for user input
-  CI               installs in CI mode (e.g. does not prompt for user input)
+  TANAAB_BREWFILE  same as --brewfile
+  TANAAB_DOTPKG    same as --dotpkg
+  TANAAB_SSH_KEY   same as --ssh-key
+  TANAAB_OP_TOKEN  same as --op-token; falls back to OP_SERVICE_ACCOUNT_TOKEN
+  TANAAB_TARGET    same as --target
+  TANAAB_FORCE     same as --force
+  TANAAB_DEBUG     same as --debug
+  NONINTERACTIVE   same as --yes
+  CI               runs in CI mode and disables prompts
 EOS
   if [[ "${1:-0}" != "noexit" ]]; then
     exit "${1:-0}"
@@ -333,9 +362,33 @@ show_version() {
   exit 0
 }
 
+abort_option_usage() {
+  usage "noexit"
+  abort "$1"
+}
+
+require_next_option_value() {
+  local option="$1"
+  local argc="$2"
+
+  if [[ "${argc}" -lt 2 ]]; then
+    abort_option_usage "option ${tty_bold}${option}${tty_reset} requires a value."
+  fi
+}
+
+require_inline_option_value() {
+  local option="$1"
+  local value="$2"
+
+  if [[ -z "${value}" ]]; then
+    abort_option_usage "option ${tty_bold}${option}${tty_reset} must not be empty."
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --brewfile)
+      require_next_option_value "--brewfile" "$#"
       append_array_value BREWFILES "$2"
       shift 2
       ;;
@@ -344,6 +397,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --brewfiles)
+      require_next_option_value "--brewfiles" "$#"
       append_csv_to_array BREWFILES "$2"
       shift 2
       ;;
@@ -352,6 +406,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --dotpkg)
+      require_next_option_value "--dotpkg" "$#"
       append_array_value DOTPKGS "$2"
       shift 2
       ;;
@@ -360,6 +415,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --dotpkgs)
+      require_next_option_value "--dotpkgs" "$#"
       append_csv_to_array DOTPKGS "$2"
       shift 2
       ;;
@@ -368,6 +424,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --ssh-key)
+      require_next_option_value "--ssh-key" "$#"
       append_array_value SSH_KEYS "$2"
       shift 2
       ;;
@@ -376,6 +433,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --ssh-keys)
+      require_next_option_value "--ssh-keys" "$#"
       append_csv_to_array SSH_KEYS "$2"
       shift 2
       ;;
@@ -384,6 +442,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --op-token)
+      require_next_option_value "--op-token" "$#"
       OP_TOKEN="$2"
       shift 2
       ;;
@@ -406,10 +465,13 @@ while [[ $# -gt 0 ]]; do
       ;;
 
     --target)
+      require_next_option_value "--target" "$#"
+      require_inline_option_value "--target" "$2"
       TARGET="$2"
       shift 2
       ;;
     --target=*)
+      require_inline_option_value "--target" "${1#*=}"
       TARGET="${1#*=}"
       shift
       ;;
@@ -426,7 +488,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       usage "noexit"
-      abort "${tty_red}Unrecognized option${tty_reset} ${tty_bold}$1${tty_reset}! See available options in usage above."
+      abort "unrecognized option ${tty_bold}$1${tty_reset}; see usage above."
       ;;
   esac
 done
@@ -739,30 +801,19 @@ fi
 
 # redefine this one
 abort() {
-  printf "${tty_red}ERROR${tty_reset}: %s\n" "$(chomp "$1")" >&2
+  printf "${tty_red}error${tty_reset}: %s\n" "$(chomp "$1")" >&2
   exit 1
 }
 
 abort_multi() {
   while read -r line; do
-    printf "${tty_red}ERROR${tty_reset}: %s\n" "$(chomp "$line")" >&2
+    printf "${tty_red}error${tty_reset}: %s\n" "$(chomp "$line")" >&2
   done <<< "$@"
   exit 1
 }
 
 chomp() {
   printf "%s" "${1/"$'\n'"/}"
-}
-
-value_enabled() {
-  case "${1:-}" in
-    '' | 0 | false | FALSE | False | no | NO | No | off | OFF | Off)
-      return 1
-      ;;
-    *)
-      return 0
-      ;;
-  esac
 }
 
 debug_enabled() {
@@ -812,7 +863,7 @@ shell_join() {
 }
 
 warn() {
-  printf "${tty_yellow}warning${tty_reset}: %s\n" "$(chomp "$@")" >&2
+  printf "${tty_yellow}warn${tty_reset}: %s\n" "$(chomp "$@")" >&2
 }
 
 # shellcheck disable=SC2329
@@ -1841,14 +1892,14 @@ needs_sudo() {
 # abort if run as root
 # @NOTE: this might change in the future but right now we do not understand all the complexities around this
 if [[ "${EUID:-${UID}}" == "0" ]]; then
-  abort "Cannot run this script as root"
+  abort "cannot run this script as root."
 fi
 
 # abort if unsupported os
 if [[ "${OS}" != "macos" ]]; then
   abort_multi "$(cat <<EOABORT
-This script is only for ${tty_green}macOS${tty_reset}. ${tty_red}${OS}${tty_reset} is not supported!
-Check the project README for current support details: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
+this script only supports ${tty_ts}macOS${tty_reset}; ${tty_red}${OS}${tty_reset} is not supported.
+check the project README for current support details: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
 EOABORT
 )"
 fi
@@ -1856,8 +1907,8 @@ fi
 # abort if unsupported arch
 if [[ "${ARCH}" != "x64" ]] && [[ "${ARCH}" != "arm64" ]]; then
   abort_multi "$(cat <<EOABORT
-This script currently only supports ${tty_green}x64${tty_reset} and ${tty_green}arm64${tty_reset} systems.
-Check the project README for current support details: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
+this script currently only supports ${tty_ts}x64${tty_reset} and ${tty_ts}arm64${tty_reset} systems.
+check the project README for current support details: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
 EOABORT
 )"
 fi
@@ -1867,8 +1918,8 @@ if [[ "${OS}" == "macos" ]]; then
   macos_version="$(major_minor "$(/usr/bin/sw_vers -productVersion)")"
   if ! version_compare "${macos_version}" "${MACOS_OLDEST_SUPPORTED}"; then
     abort_multi "$(cat <<EOABORT
-Your macOS version ${tty_red}${macos_version}${tty_reset} is ${tty_bold}too old${tty_reset}! Min required version is ${tty_green}${MACOS_OLDEST_SUPPORTED}${tty_reset}
-Check the project README for current support details: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
+your macOS version ${tty_red}${macos_version}${tty_reset} is ${tty_bold}too old${tty_reset}; minimum supported version is ${tty_ts}${MACOS_OLDEST_SUPPORTED}${tty_reset}.
+check the project README for current support details: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
 EOABORT
 )"
   fi
@@ -1890,9 +1941,9 @@ refresh_permission_dirs
 
 if needs_sudo && ! have_sudo_access; then
   abort_multi "$(cat <<EOABORT
-${tty_bold}${USER}${tty_reset} cannot write to ${tty_red}${TARGET}${tty_reset} or the expected Homebrew location ${tty_red}${HOMEBREW_PREFIX}${tty_reset} and is not a ${tty_bold}sudo${tty_reset} user!
-Rerun setup with a sudoer or use --target to install into a directory ${tty_bold}${USER}${tty_reset} can write to.
-For more information on advanced usage rerun with --help or check out: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
+${tty_bold}${USER}${tty_reset} cannot write to ${tty_red}${TARGET}${tty_reset} or the expected Homebrew location ${tty_red}${HOMEBREW_PREFIX}${tty_reset} and is not a ${tty_bold}sudo${tty_reset} user.
+rerun setup with a sudoer or use --target to install into a directory ${tty_bold}${USER}${tty_reset} can write to.
+for more information on advanced usage rerun with --help or check out: ${tty_underline}${tty_magenta}https://github.com/tanaabased/bootbox${tty_reset}
 EOABORT
 )"
 fi
@@ -1905,18 +1956,18 @@ fi
 # shellcheck disable=SC2016
 if [[ -z "${NONINTERACTIVE-}" ]]; then
   if [[ -n "${CI-}" ]]; then
-    warn 'Running in non-interactive mode because `$CI` is set.'
+    warn 'running in non-interactive mode because `$CI` is set.'
     NONINTERACTIVE=1
   elif [[ ! -t 0 ]]; then
     if [[ -z "${INTERACTIVE-}" ]];  then
-      warn 'Running in non-interactive mode because `stdin` is not a TTY.'
+      warn 'running in non-interactive mode because `stdin` is not a TTY.'
       NONINTERACTIVE=1
     else
-      warn 'Running in interactive mode despite `stdin` not being a TTY because `$INTERACTIVE` is set.'
+      warn 'running in interactive mode despite `stdin` not being a TTY because `$INTERACTIVE` is set.'
     fi
   fi
 else
-  log "${tty_tp}running${tty_reset} in ${tty_yellow}non-interactive mode${tty_reset} ${tty_dim}because \$NONINTERACTIVE is set${tty_reset}"
+  log "${tty_tp}running${tty_reset} in ${tty_ts}non-interactive mode${tty_reset} ${tty_dim}because \$NONINTERACTIVE is set${tty_reset}"
 fi
 
 ####################################################################### script
@@ -1932,7 +1983,7 @@ getc() {
 execute() {
   debug "${tty_tp}running${tty_reset}" "$@"
   if ! "$@"; then
-    abort "$(printf "Failed during: %s" "$(shell_join "$@")")"
+    abort "$(printf "failed during: %s" "$(shell_join "$@")")"
   fi
 }
 

--- a/examples/bootbox-brewfiles-env/README.md
+++ b/examples/bootbox-brewfiles-env/README.md
@@ -1,6 +1,6 @@
 # Bootbox Brewfiles Env Example
 
-This example uses `TANAAB_BREWFILE` and `TANAAB_DEBUG` to exercise multi-source Brewfile handling
+This example uses `BOOTBOX_BREWFILE` and `BOOTBOX_DEBUG` to exercise multi-source Brewfile handling
 with a local Brewfile and a `file://` Brewfile URL, then verifies the requested formulas are
 available afterwards.
 
@@ -13,9 +13,9 @@ rm -rf .tmp && mkdir -p .tmp/home
 # should run bootbox with local and file-url brewfiles from environment variables
 url_brewfile="file://$(pwd)/Brewfile.url" && \
 CI=1 NONINTERACTIVE=1 \
-TANAAB_BREWFILE="Brewfile.base,$url_brewfile" \
-TANAAB_DEBUG=1 \
-TANAAB_TARGET="$(pwd)/.tmp/home" \
+BOOTBOX_BREWFILE="Brewfile.base,$url_brewfile" \
+BOOTBOX_DEBUG=1 \
+BOOTBOX_TARGET="$(pwd)/.tmp/home" \
 bootbox > .tmp/setup.log 2>&1
 ```
 

--- a/examples/bootbox-cli-contract/README.md
+++ b/examples/bootbox-cli-contract/README.md
@@ -32,6 +32,7 @@ bootbox --help | grep -F -- '--op-token'
 bootbox --help | grep -F -- '--target'
 bootbox --help | grep -F -- '--version'
 bootbox --help | grep -F -- '--debug'
+bootbox --help | grep -F -- '--quiet'
 bootbox --help | grep -F -- '--force'
 bootbox --help | grep -F -- '--yes'
 
@@ -42,6 +43,7 @@ bootbox --help | grep -F 'TANAAB_SSH_KEY   same as --ssh-key'
 bootbox --help | grep -F 'TANAAB_OP_TOKEN  same as --op-token; falls back to OP_SERVICE_ACCOUNT_TOKEN'
 bootbox --help | grep -F 'TANAAB_TARGET    same as --target'
 bootbox --help | grep -F 'TANAAB_FORCE     same as --force'
+bootbox --help | grep -F 'TANAAB_QUIET     same as --quiet'
 bootbox --help | grep -F 'TANAAB_DEBUG     same as --debug'
 bootbox --help | grep -F 'NONINTERACTIVE   same as --yes'
 bootbox --help | grep -F 'CI               runs in CI mode and disables prompts'
@@ -63,6 +65,11 @@ test ! -s .tmp/check-core.log
 bootbox --debug --check-core > .tmp/check-core-debug.log 2>&1 || test "$?" -eq 1
 grep -F 'running hidden --check-core mode' .tmp/check-core-debug.log
 
+# should keep debug logging on stderr when quiet mode is enabled
+bootbox --quiet --debug --check-core > .tmp/check-core-quiet.stdout 2> .tmp/check-core-quiet.stderr || test "$?" -eq 1
+test ! -s .tmp/check-core-quiet.stdout
+grep -F 'running hidden --check-core mode' .tmp/check-core-quiet.stderr
+
 # should mask token defaults in help
 TANAAB_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secr...alue'
 if TANAAB_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secret-example-value'; then exit 1; fi
@@ -70,9 +77,12 @@ if TANAAB_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secret-examp
 # should allow an inline empty op token to mean no token
 TANAAB_OP_TOKEN='secret-example-value' bootbox --op-token= --help | grep -F -- '--op-token       auths with 1password service account token [default: none]'
 
-# should show debug and force defaults
+# should show debug, quiet, and force defaults
 bootbox --help | grep -F -- '--debug          shows debug messages [default: off]'
 bootbox --debug --help | grep -F -- '--debug          shows debug messages [default: on]'
+bootbox --help | grep -F -- '--quiet          suppresses bootbox status output [default: off]'
+bootbox --quiet --help | grep -F -- '--quiet          suppresses bootbox status output [default: on]'
+TANAAB_QUIET=1 bootbox --help | grep -F -- '--quiet          suppresses bootbox status output [default: on]'
 bootbox --help | grep -F -- '--force          forces supported overwrite operations [default: off]'
 bootbox --force --help | grep -F -- '--force          forces supported overwrite operations [default: on]'
 

--- a/examples/bootbox-cli-contract/README.md
+++ b/examples/bootbox-cli-contract/README.md
@@ -33,6 +33,7 @@ bootbox --help | grep -F -- '--target'
 bootbox --help | grep -F -- '--version'
 bootbox --help | grep -F -- '--debug'
 bootbox --help | grep -F -- '--quiet'
+bootbox --help | grep -F -- '--no-sudo'
 bootbox --help | grep -F -- '--force'
 bootbox --help | grep -F -- '--yes'
 
@@ -44,6 +45,7 @@ bootbox --help | grep -F 'BOOTBOX_OP_TOKEN same as --op-token; falls back to OP_
 bootbox --help | grep -F 'BOOTBOX_TARGET   same as --target'
 bootbox --help | grep -F 'BOOTBOX_FORCE    same as --force'
 bootbox --help | grep -F 'BOOTBOX_QUIET    same as --quiet'
+bootbox --help | grep -F 'BOOTBOX_NO_SUDO  same as --no-sudo'
 bootbox --help | grep -F 'BOOTBOX_DEBUG    same as --debug'
 bootbox --help | grep -F 'NONINTERACTIVE   same as --yes'
 bootbox --help | grep -F 'CI               runs in CI mode and disables prompts'
@@ -80,12 +82,15 @@ if BOOTBOX_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secret-exam
 # should allow an inline empty op token to mean no token
 BOOTBOX_OP_TOKEN='secret-example-value' bootbox --op-token= --help | grep -F -- '--op-token       auths with 1password service account token [default: none]'
 
-# should show debug, quiet, and force defaults
+# should show debug, quiet, no-sudo, and force defaults
 bootbox --help | grep -F -- '--debug          shows debug messages [default: off]'
 bootbox --debug --help | grep -F -- '--debug          shows debug messages [default: on]'
 bootbox --help | grep -F -- '--quiet          suppresses bootbox status output [default: off]'
 bootbox --quiet --help | grep -F -- '--quiet          suppresses bootbox status output [default: on]'
 BOOTBOX_QUIET=1 bootbox --help | grep -F -- '--quiet          suppresses bootbox status output [default: on]'
+bootbox --help | grep -F -- '--no-sudo        disables sudo checks, prompts, and elevation [default: off]'
+bootbox --no-sudo --help | grep -F -- '--no-sudo        disables sudo checks, prompts, and elevation [default: on]'
+BOOTBOX_NO_SUDO=1 bootbox --help | grep -F -- '--no-sudo        disables sudo checks, prompts, and elevation [default: on]'
 bootbox --help | grep -F -- '--force          forces supported overwrite operations [default: off]'
 bootbox --force --help | grep -F -- '--force          forces supported overwrite operations [default: on]'
 

--- a/examples/bootbox-cli-contract/README.md
+++ b/examples/bootbox-cli-contract/README.md
@@ -1,29 +1,56 @@
 # Bootbox CLI Contract Example
 
-This example keeps coverage on the shell-facing contract of `bootbox`: help output, version output,
-and a clear failure for unknown options.
+This example keeps lightweight coverage on the public `bootbox` interface. It validates help,
+version, hidden probes, option precedence display, token masking, and clean argument failures without
+running the full bootstrap path.
 
 ## Setup
 
 ```bash
 # should reset the example scratch directory
 rm -rf .tmp && mkdir -p .tmp
+
+# should have prepared bootbox on PATH
+command -v bootbox >/dev/null
 ```
 
 ## Testing
 
 ```bash
-# should show the brewfile flag in help output
-bootbox --help | grep -- '--brewfile'
+# should show bootbox usage
+bootbox --help | grep -F 'Usage:'
+bootbox --help | grep -F '[NONINTERACTIVE=1]'
+bootbox --help | grep -F '[CI=1]'
+bootbox --help | grep -F '[TANAAB_*...]'
+bootbox --help | grep -F 'bootbox [options]'
 
-# should show the dotpkg env var in help output
-bootbox --help | grep -- 'TANAAB_DOTPKG'
+# should document public options
+bootbox --help | grep -F -- '--brewfile'
+bootbox --help | grep -F -- '--dotpkg'
+bootbox --help | grep -F -- '--ssh-key'
+bootbox --help | grep -F -- '--op-token'
+bootbox --help | grep -F -- '--target'
+bootbox --help | grep -F -- '--version'
+bootbox --help | grep -F -- '--debug'
+bootbox --help | grep -F -- '--force'
+bootbox --help | grep -F -- '--yes'
 
-# should show the invoked command name in usage output
-bootbox --help | grep -E 'Usage: .*bootbox '
+# should document public environment variables
+bootbox --help | grep -F 'TANAAB_BREWFILE  same as --brewfile'
+bootbox --help | grep -F 'TANAAB_DOTPKG    same as --dotpkg'
+bootbox --help | grep -F 'TANAAB_SSH_KEY   same as --ssh-key'
+bootbox --help | grep -F 'TANAAB_OP_TOKEN  same as --op-token; falls back to OP_SERVICE_ACCOUNT_TOKEN'
+bootbox --help | grep -F 'TANAAB_TARGET    same as --target'
+bootbox --help | grep -F 'TANAAB_FORCE     same as --force'
+bootbox --help | grep -F 'TANAAB_DEBUG     same as --debug'
+bootbox --help | grep -F 'NONINTERACTIVE   same as --yes'
+bootbox --help | grep -F 'CI               runs in CI mode and disables prompts'
+
+# should not expose a CI option
+if bootbox --help | grep -F -- '--ci'; then exit 1; fi
 
 # should keep the hidden core check out of help output
-! bootbox --help | grep -- '--check-core'
+if bootbox --help | grep -F -- '--check-core'; then exit 1; fi
 
 # should print a version string
 test -n "$(bootbox --version)"
@@ -36,11 +63,48 @@ test ! -s .tmp/check-core.log
 bootbox --debug --check-core > .tmp/check-core-debug.log 2>&1 || test "$?" -eq 1
 grep -F 'running hidden --check-core mode' .tmp/check-core-debug.log
 
-# should fail for an unknown option
-! bootbox --definitely-bogus > .tmp/invalid.log 2>&1
+# should mask token defaults in help
+TANAAB_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secr...alue'
+if TANAAB_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secret-example-value'; then exit 1; fi
 
-# should explain the unknown option failure
-grep -F 'Unrecognized option' .tmp/invalid.log
+# should allow an inline empty op token to mean no token
+TANAAB_OP_TOKEN='secret-example-value' bootbox --op-token= --help | grep -F -- '--op-token       auths with 1password service account token [default: none]'
+
+# should show debug and force defaults
+bootbox --help | grep -F -- '--debug          shows debug messages [default: off]'
+bootbox --debug --help | grep -F -- '--debug          shows debug messages [default: on]'
+bootbox --help | grep -F -- '--force          forces supported overwrite operations [default: off]'
+bootbox --force --help | grep -F -- '--force          forces supported overwrite operations [default: on]'
+
+# should let inline empty brewfile values clear env defaults
+TANAAB_BREWFILE='Brewfile.example' bootbox --brewfile= --help | grep -F -- '--brewfile       installs brewfiles from local paths or URLs [default: none]'
+TANAAB_BREWFILE='Brewfile.example' bootbox --brewfiles= --help | grep -F -- '--brewfile       installs brewfiles from local paths or URLs [default: none]'
+
+# should let inline empty dotpkg values clear env defaults
+TANAAB_DOTPKG='dotpkgs/git' bootbox --dotpkg= --help | grep -F -- '--dotpkg         stows dot packages into target [default: none]'
+TANAAB_DOTPKG='dotpkgs/git' bootbox --dotpkgs= --help | grep -F -- '--dotpkg         stows dot packages into target [default: none]'
+
+# should let inline empty ssh key values clear env defaults
+TANAAB_SSH_KEY='vault/item' bootbox --ssh-key= --help | grep -F -- '--ssh-key        installs 1password ssh keys into target .ssh as vault/item[:filename] [default: none]'
+TANAAB_SSH_KEY='vault/item' bootbox --ssh-keys= --help | grep -F -- '--ssh-key        installs 1password ssh keys into target .ssh as vault/item[:filename] [default: none]'
+
+# should fail cleanly when a separated value is missing
+! bootbox --brewfile > .tmp/missing-brewfile.log 2>&1
+grep -F 'error: option --brewfile requires a value.' .tmp/missing-brewfile.log
+grep -F 'Usage:' .tmp/missing-brewfile.log
+! bootbox --op-token > .tmp/missing-op-token.log 2>&1
+grep -F 'error: option --op-token requires a value.' .tmp/missing-op-token.log
+! bootbox --target > .tmp/missing-target.log 2>&1
+grep -F 'error: option --target requires a value.' .tmp/missing-target.log
+
+# should reject an empty target value
+! bootbox --target= > .tmp/empty-target.log 2>&1
+grep -F 'error: option --target must not be empty.' .tmp/empty-target.log
+
+# should fail for an unknown option with usage context
+! bootbox --definitely-bogus > .tmp/invalid.log 2>&1
+grep -F 'error: unrecognized option' .tmp/invalid.log
+grep -F 'Usage:' .tmp/invalid.log
 ```
 
 ## Destroy tests

--- a/examples/bootbox-cli-contract/README.md
+++ b/examples/bootbox-cli-contract/README.md
@@ -21,7 +21,7 @@ command -v bootbox >/dev/null
 bootbox --help | grep -F 'Usage:'
 bootbox --help | grep -F '[NONINTERACTIVE=1]'
 bootbox --help | grep -F '[CI=1]'
-bootbox --help | grep -F '[TANAAB_*...]'
+bootbox --help | grep -F '[BOOTBOX_*...]'
 bootbox --help | grep -F 'bootbox [options]'
 
 # should document public options
@@ -37,16 +37,19 @@ bootbox --help | grep -F -- '--force'
 bootbox --help | grep -F -- '--yes'
 
 # should document public environment variables
-bootbox --help | grep -F 'TANAAB_BREWFILE  same as --brewfile'
-bootbox --help | grep -F 'TANAAB_DOTPKG    same as --dotpkg'
-bootbox --help | grep -F 'TANAAB_SSH_KEY   same as --ssh-key'
-bootbox --help | grep -F 'TANAAB_OP_TOKEN  same as --op-token; falls back to OP_SERVICE_ACCOUNT_TOKEN'
-bootbox --help | grep -F 'TANAAB_TARGET    same as --target'
-bootbox --help | grep -F 'TANAAB_FORCE     same as --force'
-bootbox --help | grep -F 'TANAAB_QUIET     same as --quiet'
-bootbox --help | grep -F 'TANAAB_DEBUG     same as --debug'
+bootbox --help | grep -F 'BOOTBOX_BREWFILE same as --brewfile'
+bootbox --help | grep -F 'BOOTBOX_DOTPKG   same as --dotpkg'
+bootbox --help | grep -F 'BOOTBOX_SSH_KEY  same as --ssh-key'
+bootbox --help | grep -F 'BOOTBOX_OP_TOKEN same as --op-token; falls back to OP_SERVICE_ACCOUNT_TOKEN'
+bootbox --help | grep -F 'BOOTBOX_TARGET   same as --target'
+bootbox --help | grep -F 'BOOTBOX_FORCE    same as --force'
+bootbox --help | grep -F 'BOOTBOX_QUIET    same as --quiet'
+bootbox --help | grep -F 'BOOTBOX_DEBUG    same as --debug'
 bootbox --help | grep -F 'NONINTERACTIVE   same as --yes'
 bootbox --help | grep -F 'CI               runs in CI mode and disables prompts'
+
+# should not document legacy environment variables
+if bootbox --help | grep -F 'TANAAB_'; then exit 1; fi
 
 # should not expose a CI option
 if bootbox --help | grep -F -- '--ci'; then exit 1; fi
@@ -71,32 +74,32 @@ test ! -s .tmp/check-core-quiet.stdout
 grep -F 'running hidden --check-core mode' .tmp/check-core-quiet.stderr
 
 # should mask token defaults in help
-TANAAB_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secr...alue'
-if TANAAB_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secret-example-value'; then exit 1; fi
+BOOTBOX_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secr...alue'
+if BOOTBOX_OP_TOKEN='secret-example-value' bootbox --help | grep -F 'secret-example-value'; then exit 1; fi
 
 # should allow an inline empty op token to mean no token
-TANAAB_OP_TOKEN='secret-example-value' bootbox --op-token= --help | grep -F -- '--op-token       auths with 1password service account token [default: none]'
+BOOTBOX_OP_TOKEN='secret-example-value' bootbox --op-token= --help | grep -F -- '--op-token       auths with 1password service account token [default: none]'
 
 # should show debug, quiet, and force defaults
 bootbox --help | grep -F -- '--debug          shows debug messages [default: off]'
 bootbox --debug --help | grep -F -- '--debug          shows debug messages [default: on]'
 bootbox --help | grep -F -- '--quiet          suppresses bootbox status output [default: off]'
 bootbox --quiet --help | grep -F -- '--quiet          suppresses bootbox status output [default: on]'
-TANAAB_QUIET=1 bootbox --help | grep -F -- '--quiet          suppresses bootbox status output [default: on]'
+BOOTBOX_QUIET=1 bootbox --help | grep -F -- '--quiet          suppresses bootbox status output [default: on]'
 bootbox --help | grep -F -- '--force          forces supported overwrite operations [default: off]'
 bootbox --force --help | grep -F -- '--force          forces supported overwrite operations [default: on]'
 
 # should let inline empty brewfile values clear env defaults
-TANAAB_BREWFILE='Brewfile.example' bootbox --brewfile= --help | grep -F -- '--brewfile       installs brewfiles from local paths or URLs [default: none]'
-TANAAB_BREWFILE='Brewfile.example' bootbox --brewfiles= --help | grep -F -- '--brewfile       installs brewfiles from local paths or URLs [default: none]'
+BOOTBOX_BREWFILE='Brewfile.example' bootbox --brewfile= --help | grep -F -- '--brewfile       installs brewfiles from local paths or URLs [default: none]'
+BOOTBOX_BREWFILE='Brewfile.example' bootbox --brewfiles= --help | grep -F -- '--brewfile       installs brewfiles from local paths or URLs [default: none]'
 
 # should let inline empty dotpkg values clear env defaults
-TANAAB_DOTPKG='dotpkgs/git' bootbox --dotpkg= --help | grep -F -- '--dotpkg         stows dot packages into target [default: none]'
-TANAAB_DOTPKG='dotpkgs/git' bootbox --dotpkgs= --help | grep -F -- '--dotpkg         stows dot packages into target [default: none]'
+BOOTBOX_DOTPKG='dotpkgs/git' bootbox --dotpkg= --help | grep -F -- '--dotpkg         stows dot packages into target [default: none]'
+BOOTBOX_DOTPKG='dotpkgs/git' bootbox --dotpkgs= --help | grep -F -- '--dotpkg         stows dot packages into target [default: none]'
 
 # should let inline empty ssh key values clear env defaults
-TANAAB_SSH_KEY='vault/item' bootbox --ssh-key= --help | grep -F -- '--ssh-key        installs 1password ssh keys into target .ssh as vault/item[:filename] [default: none]'
-TANAAB_SSH_KEY='vault/item' bootbox --ssh-keys= --help | grep -F -- '--ssh-key        installs 1password ssh keys into target .ssh as vault/item[:filename] [default: none]'
+BOOTBOX_SSH_KEY='vault/item' bootbox --ssh-key= --help | grep -F -- '--ssh-key        installs 1password ssh keys into target .ssh as vault/item[:filename] [default: none]'
+BOOTBOX_SSH_KEY='vault/item' bootbox --ssh-keys= --help | grep -F -- '--ssh-key        installs 1password ssh keys into target .ssh as vault/item[:filename] [default: none]'
 
 # should fail cleanly when a separated value is missing
 ! bootbox --brewfile > .tmp/missing-brewfile.log 2>&1

--- a/examples/bootbox-dotpkgs-env/README.md
+++ b/examples/bootbox-dotpkgs-env/README.md
@@ -1,6 +1,6 @@
 # Bootbox Dotpkgs Env Example
 
-This example uses the `TANAAB_DOTPKG` and `TANAAB_TARGET` environment variables to stow multiple
+This example uses the `BOOTBOX_DOTPKG` and `BOOTBOX_TARGET` environment variables to stow multiple
 dot packages into an example-local target directory.
 
 ## Setup
@@ -11,8 +11,8 @@ rm -rf .tmp && mkdir -p .tmp/home
 
 # should stow the requested dotpkgs from environment variables
 CI=1 NONINTERACTIVE=1 \
-TANAAB_DOTPKG="dotpkgs/git,dotpkgs/vim" \
-TANAAB_TARGET="$(pwd)/.tmp/home" \
+BOOTBOX_DOTPKG="dotpkgs/git,dotpkgs/vim" \
+BOOTBOX_TARGET="$(pwd)/.tmp/home" \
 bootbox > .tmp/setup.log 2>&1
 ```
 

--- a/examples/bootbox-dotpkgs-force-backup/README.md
+++ b/examples/bootbox-dotpkgs-force-backup/README.md
@@ -1,7 +1,7 @@
 # Bootbox Dotpkgs Force Backup Example
 
 This example verifies that Bootbox backs up conflicting target files before stowing a replacement
-when `TANAAB_FORCE=1` is set.
+when `BOOTBOX_FORCE=1` is set.
 
 ## Setup
 
@@ -17,9 +17,9 @@ EOF
 
 # should back up the conflicting file when force mode is enabled
 CI=1 NONINTERACTIVE=1 \
-TANAAB_DOTPKG="dotpkgs/git" \
-TANAAB_FORCE=1 \
-TANAAB_TARGET="$(pwd)/.tmp/home" \
+BOOTBOX_DOTPKG="dotpkgs/git" \
+BOOTBOX_FORCE=1 \
+BOOTBOX_TARGET="$(pwd)/.tmp/home" \
 bootbox > .tmp/setup.log 2>&1
 ```
 

--- a/examples/bootbox-dotpkgs-force-backup/README.md
+++ b/examples/bootbox-dotpkgs-force-backup/README.md
@@ -1,6 +1,6 @@
 # Bootbox Dotpkgs Force Backup Example
 
-This example verifies that Bootbox backs up conflicting target files before stowing a replacement
+This example verifies that `bootbox` backs up conflicting target files before stowing a replacement
 when `BOOTBOX_FORCE=1` is set.
 
 ## Setup

--- a/examples/bootbox-legacy-env-compat/README.md
+++ b/examples/bootbox-legacy-env-compat/README.md
@@ -1,0 +1,66 @@
+# Bootbox Legacy Env Compatibility Example
+
+This example covers transitional compatibility for the old `TANAAB_*` environment namespace. New
+callers should use `BOOTBOX_*`; this legacy support is not the forward public contract and will be
+removed in a future release.
+
+## Setup
+
+```bash
+# should reset the example scratch directory
+rm -rf .tmp && mkdir -p .tmp
+
+# should have prepared bootbox on PATH
+command -v bootbox >/dev/null
+```
+
+## Testing
+
+```bash
+# should keep legacy environment variables out of help output
+if bootbox --help | grep -F 'TANAAB_'; then exit 1; fi
+
+# should accept legacy list environment defaults
+TANAAB_BREWFILE='Brewfile.legacy' TANAAB_BREWFILES='Brewfile.extra' bootbox --help | grep -F -- '--brewfile       installs brewfiles from local paths or URLs [default: Brewfile.legacy,Brewfile.extra]'
+TANAAB_DOTPKG='dotpkgs/legacy' TANAAB_DOTPKGS='dotpkgs/extra' bootbox --help | grep -F -- '--dotpkg         stows dot packages into target [default: dotpkgs/legacy,dotpkgs/extra]'
+TANAAB_SSH_KEY='vault/item' TANAAB_SSH_KEYS='vault/extra' bootbox --help | grep -F -- '--ssh-key        installs 1password ssh keys into target .ssh as vault/item[:filename] [default: vault/item,vault/extra]'
+
+# should accept legacy scalar environment defaults
+TANAAB_TARGET='/tmp/bootbox-legacy-target' bootbox --help | grep -F -- '--target         installs dotpkgs and identities relative to here [default: /tmp/bootbox-legacy-target]'
+TANAAB_FORCE=1 bootbox --help | grep -F -- '--force          forces supported overwrite operations [default: on]'
+TANAAB_QUIET=1 bootbox --help | grep -F -- '--quiet          suppresses bootbox status output [default: on]'
+TANAAB_DEBUG=1 bootbox --help | grep -F -- '--debug          shows debug messages [default: on]'
+
+# should mask legacy token defaults in help
+TANAAB_OP_TOKEN='legacy-token-5678' bootbox --help | grep -F 'lega...5678'
+if TANAAB_OP_TOKEN='legacy-token-5678' bootbox --help | grep -F 'legacy-token-5678'; then exit 1; fi
+
+# should prefer bootbox scalar environment defaults over legacy defaults
+BOOTBOX_TARGET='/tmp/bootbox-preferred-target' TANAAB_TARGET='/tmp/bootbox-legacy-target' bootbox --help | grep -F -- '--target         installs dotpkgs and identities relative to here [default: /tmp/bootbox-preferred-target]'
+if BOOTBOX_TARGET='/tmp/bootbox-preferred-target' TANAAB_TARGET='/tmp/bootbox-legacy-target' bootbox --help | grep -F '/tmp/bootbox-legacy-target'; then exit 1; fi
+
+# should prefer bootbox list environment defaults over legacy defaults
+BOOTBOX_BREWFILE='Brewfile.preferred' TANAAB_BREWFILE='Brewfile.legacy' TANAAB_BREWFILES='Brewfile.extra' bootbox --help | grep -F -- '--brewfile       installs brewfiles from local paths or URLs [default: Brewfile.preferred]'
+if BOOTBOX_BREWFILE='Brewfile.preferred' TANAAB_BREWFILE='Brewfile.legacy' TANAAB_BREWFILES='Brewfile.extra' bootbox --help | grep -F 'Brewfile.legacy'; then exit 1; fi
+
+# should prefer bootbox token defaults over legacy token defaults
+BOOTBOX_OP_TOKEN='preferred-token-1234' TANAAB_OP_TOKEN='legacy-token-5678' bootbox --help | grep -F 'pref...1234'
+if BOOTBOX_OP_TOKEN='preferred-token-1234' TANAAB_OP_TOKEN='legacy-token-5678' bootbox --help | grep -F 'lega...5678'; then exit 1; fi
+
+# should allow legacy debug to keep hidden core probe diagnostics on stderr
+TANAAB_DEBUG=1 bootbox --check-core > .tmp/check-core-legacy.stdout 2> .tmp/check-core-legacy.stderr || test "$?" -eq 1
+test ! -s .tmp/check-core-legacy.stdout
+grep -F 'running hidden --check-core mode' .tmp/check-core-legacy.stderr
+
+# should accept legacy platform override values
+TANAAB_DEBUG=1 TANAAB_ARCH=arm64 TANAAB_OS=macos bootbox --check-core > .tmp/platform-legacy.stdout 2> .tmp/platform-legacy.stderr || test "$?" -eq 1
+grep -F 'raw ARCH=arm64' .tmp/platform-legacy.stderr
+grep -F 'raw OS=macos' .tmp/platform-legacy.stderr
+```
+
+## Destroy tests
+
+```bash
+# should remove the example scratch directory
+rm -rf .tmp
+```

--- a/examples/bootbox-minimal/README.md
+++ b/examples/bootbox-minimal/README.md
@@ -1,6 +1,6 @@
 # Bootbox Minimal Example
 
-This example is the smallest markdown-first bootstrap test for `bootbox`. It forces Bootbox's
+This example is the smallest markdown-first bootstrap test for `bootbox`. It forces `bootbox`'s
 core readiness check into a failing state when Homebrew is already present, then runs the default
 setup path against an example-local target directory and verifies that the core check and expected
 toolchain are satisfied afterwards.

--- a/examples/bootbox-ssh-keys-flags/README.md
+++ b/examples/bootbox-ssh-keys-flags/README.md
@@ -10,7 +10,7 @@ key twice: once with the default filename and once with a filename override.
 rm -rf .tmp && mkdir -p .tmp/home
 
 # should have the 1password test token available
-test -n "$TANAAB_OP_TESTVAULT"
+test -n "$BOOTBOX_OP_TESTVAULT"
 
 # should install the requested ssh keys from 1password
 CI=1 NONINTERACTIVE=1 \
@@ -18,7 +18,7 @@ bootbox \
   --target "$(pwd)/.tmp/home" \
   --ssh-key "omfsw2uztmi2xqpid5g3kiv6ba/id_test" \
   --ssh-key "omfsw2uztmi2xqpid5g3kiv6ba/id_test:id_test_bootbox" \
-  --op-token "$TANAAB_OP_TESTVAULT" \
+  --op-token "$BOOTBOX_OP_TESTVAULT" \
   > .tmp/setup.log 2>&1
 ```
 

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -1,21 +1,43 @@
 import { execFile } from 'node:child_process';
-import { chmod, cp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
+import { chmod, copyFile, mkdir, rm, stat, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
+const execFileAsync = promisify(execFile);
 const REPO_URL = new URL('../', import.meta.url);
 const REPO_ROOT = fileURLToPath(REPO_URL);
 const DIST_URL = new URL('./dist/', REPO_URL);
 const PUBLIC_ORIGIN = 'https://bootbox.tanaab.sh';
+const PUBLISHED_SCRIPTS = [
+  {
+    sourcePath: 'bootbox.sh',
+    destinationPath: 'bootbox.sh',
+    executable: true,
+  },
+];
+const DIST_FILES = [
+  ...PUBLISHED_SCRIPTS,
+  {
+    sourcePath: 'site/index.html',
+    destinationPath: 'index.html',
+    executable: false,
+  },
+  {
+    sourcePath: 'site/llms.txt',
+    destinationPath: 'llms.txt',
+    executable: false,
+  },
+];
 const ROBOTS_URL = new URL('./robots.txt', DIST_URL);
 const SITEMAP_URL = new URL('./sitemap.xml', DIST_URL);
-const BOOTBOX_SOURCE_URL = new URL('./bootbox.sh', REPO_URL);
-const DIST_FILES = [
-  ['bootbox.sh', 'bootbox.sh'],
-  ['site/index.html', 'index.html'],
+const PUBLIC_RESOURCES = [
+  ...PUBLISHED_SCRIPTS.map(({ destinationPath }) => ({
+    destinationPath,
+  })),
+  {
+    destinationPath: 'llms.txt',
+  },
 ];
-const EXECUTABLES = ['bootbox.sh'];
-const execFileAsync = promisify(execFile);
 
 function log(message) {
   process.stdout.write(`${message}\n`);
@@ -39,7 +61,7 @@ async function getGitLastmod() {
   try {
     const { stdout } = await execFileAsync(
       'git',
-      ['log', '-1', '--format=%cI', '--', 'bootbox.sh'],
+      ['log', '-1', '--format=%cI', '--', ...PUBLISHED_SCRIPTS.map(({ sourcePath }) => sourcePath)],
       {
         cwd: REPO_ROOT,
       },
@@ -53,9 +75,12 @@ async function getGitLastmod() {
 
 async function getFileLastmod() {
   try {
-    const fileStats = await stat(BOOTBOX_SOURCE_URL);
+    const fileStats = await Promise.all(
+      PUBLISHED_SCRIPTS.map(({ sourcePath }) => stat(new URL(sourcePath, REPO_URL))),
+    );
+    const latestTimestamp = Math.max(...fileStats.map((entry) => entry.mtimeMs));
 
-    return normalizeLastmod(fileStats.mtime.toISOString());
+    return normalizeLastmod(new Date(latestTimestamp).toISOString());
   } catch {
     return null;
   }
@@ -84,23 +109,32 @@ async function resolveSitemapLastmod() {
 }
 
 function renderSitemap(lastmod) {
-  return `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>${PUBLIC_ORIGIN}/bootbox.sh</loc>
+  const urls = PUBLIC_RESOURCES.map(
+    ({ destinationPath }) => `  <url>
+    <loc>${PUBLIC_ORIGIN}/${destinationPath}</loc>
     <lastmod>${lastmod}</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.5</priority>
-  </url>
+  </url>`,
+  ).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
 </urlset>
 `;
 }
 
 function renderRobots() {
+  const allowedPaths = PUBLIC_RESOURCES.map(
+    ({ destinationPath }) => `Allow: /${destinationPath}`,
+  ).join('\n');
+
   return `User-agent: *
 Disallow: /
 Sitemap: ${PUBLIC_ORIGIN}/sitemap.xml
 Host: ${PUBLIC_ORIGIN}
-Allow: /bootbox.sh
+${allowedPaths}
 Allow: /sitemap.xml
 `;
 }
@@ -114,7 +148,7 @@ async function copyDistFile(sourcePath, destinationPath) {
   const sourceUrl = new URL(sourcePath, REPO_URL);
   const destinationUrl = new URL(destinationPath, DIST_URL);
 
-  await cp(sourceUrl, destinationUrl, { force: true });
+  await copyFile(sourceUrl, destinationUrl);
 
   return destinationUrl.pathname;
 }
@@ -140,7 +174,7 @@ async function writeRobots() {
 async function main() {
   await resetDist();
 
-  for (const [sourcePath, destinationPath] of DIST_FILES) {
+  for (const { sourcePath, destinationPath } of DIST_FILES) {
     const copiedPath = await copyDistFile(sourcePath, destinationPath);
     log(`copied ${copiedPath}`);
   }
@@ -148,11 +182,19 @@ async function main() {
   await writeSitemap();
   await writeRobots();
 
-  for (const executable of EXECUTABLES) {
-    await makeExecutable(executable);
+  for (const { destinationPath, executable } of PUBLISHED_SCRIPTS) {
+    if (executable) {
+      await makeExecutable(destinationPath);
+    }
   }
 
   log(`prepared ${DIST_URL.pathname}`);
 }
 
-await main();
+try {
+  await main();
+} catch (error) {
+  const output = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  process.stderr.write(`${output}\n`);
+  process.exit(1);
+}

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="refresh" content="0; url=/bootbox.sh" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Bootbox</title>
+    <title>bootbox</title>
     <script>
       const TARGETS = {
         default: '/bootbox.sh',

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,13 @@
+# Bootbox
+
+> Bootbox is a hosted macOS 26.x bootstrap script for Homebrew, Brewfiles, dotpackages, and 1Password-backed SSH key material.
+
+Bootbox is the reusable upstream bootstrap layer for Tanaab machine-profile wrappers. It owns generic Homebrew core readiness, Brewfile application, dotpackage stowing, and optional private SSH key installation. Wrapper-specific machine profiles, agent runtime setup, app onboarding, and privileged host preparation belong in downstream repos such as `me`, `emori`, and `agentbox`.
+
+## Primary Resources
+
+- [Hosted bootbox script](https://bootbox.tanaab.sh/bootbox.sh): The generated shell entrypoint for bootstrapping a Mac.
+- [GitHub repository](https://github.com/tanaabased/bootbox): Source code, README, workflows, and examples.
+- [README](https://github.com/tanaabased/bootbox#readme): Human setup, usage, configuration, and support guidance.
+- [Releases](https://github.com/tanaabased/bootbox/releases): Published release tags for hosted script updates.
+- [Issues](https://github.com/tanaabased/bootbox/issues): Bug reports, regressions, and feature requests.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,8 +1,8 @@
-# Bootbox
+# bootbox
 
-> Bootbox is a hosted macOS 26.x bootstrap script for Homebrew, Brewfiles, dotpackages, and 1Password-backed SSH key material.
+> `bootbox` is a hosted macOS 26.x bootstrap script for Homebrew, Brewfiles, dotpackages, and 1Password-backed SSH key material.
 
-Bootbox is the reusable upstream bootstrap layer for Tanaab machine-profile wrappers. It owns generic Homebrew core readiness, Brewfile application, dotpackage stowing, and optional private SSH key installation. Wrapper-specific machine profiles, agent runtime setup, app onboarding, and privileged host preparation belong in downstream repos such as `me`, `emori`, and `agentbox`.
+`bootbox` is the reusable upstream bootstrap layer for Tanaab machine-profile wrappers. It owns generic Homebrew core readiness, Brewfile application, dotpackage stowing, and optional private SSH key installation. Wrapper-specific machine profiles, agent runtime setup, app onboarding, and privileged host preparation belong in downstream repos such as `me`, `emori`, and `agentbox`.
 
 ## Primary Resources
 


### PR DESCRIPTION
## Summary

- tighten Bootbox value-taking option handling while keeping optional inputs optional
- refresh repo-local guidance, Dependabot config, hosted llms.txt, and build-dist resource handling
- expand CLI contract example coverage and add brew update before Leia example runs

## Validation

- bun run lint:eslint
- bun run format:check
- bun run lint:shellcheck
- git diff --check
- targeted CLI probes for help/version, hidden --check-core, token masking, empty list clearing, missing values, empty target rejection, unknown options, and SSH-key-with-empty-token failure

## Notes

- did not run bun run build or local Leia; dist/ remains CI-owned and unchanged locally
