### PR TITLE
add external sudo mode

### DIFF
--- a/.github/workflows/pr-examples-tests.yml
+++ b/.github/workflows/pr-examples-tests.yml
@@ -23,6 +23,7 @@ jobs:
           - bootbox-brewfiles-env
           - bootbox-ssh-keys-flags
           - bootbox-legacy-env-compat
+          - bootbox-external-sudo
     env:
       HOMEBREW_NO_AUTO_UPDATE: '1'
       BOOTBOX_OP_TESTVAULT: ${{ secrets.TANAAB_OP_TESTVAULT }}

--- a/bootbox.sh
+++ b/bootbox.sh
@@ -179,6 +179,7 @@ DEBUG="$(env_value BOOTBOX_DEBUG TANAAB_DEBUG "${DEBUG:-${RUNNER_DEBUG:-}}")"
 FORCE="$(env_value BOOTBOX_FORCE TANAAB_FORCE)"
 QUIET="$(env_value BOOTBOX_QUIET TANAAB_QUIET)"
 NO_SUDO="${BOOTBOX_NO_SUDO:-}"
+EXTERNAL_SUDO="${BOOTBOX_EXTERNAL_SUDO:-}"
 CHECK_CORE=""
 TARGET="$(env_value BOOTBOX_TARGET TANAAB_TARGET "$HOME")"
 BREWFILES_CSV="$(env_list_value BOOTBOX_BREWFILE BOOTBOX_BREWFILES TANAAB_BREWFILE TANAAB_BREWFILES)"
@@ -877,6 +878,10 @@ no_sudo_enabled() {
   value_enabled "${NO_SUDO:-}"
 }
 
+external_sudo_enabled() {
+  value_enabled "${EXTERNAL_SUDO:-}"
+}
+
 sudo_enabled() {
   ! no_sudo_enabled
 }
@@ -946,6 +951,7 @@ debug raw BREWFILES="$(array_join "," BREWFILES)"
 debug raw DOTPKGS="$(array_join "," DOTPKGS)"
 debug raw DEBUG="$DEBUG"
 debug raw FORCE="$FORCE"
+debug raw EXTERNAL_SUDO="$EXTERNAL_SUDO"
 debug raw SSH_KEYS="$(array_join "," SSH_KEYS)"
 debug raw OP_TOKEN="$(op_token_for_display)"
 debug raw HOMEBREW_PREFIX="$HOMEBREW_PREFIX"
@@ -1099,6 +1105,17 @@ have_sudo_access() {
     return 1
   fi
 
+  if external_sudo_enabled; then
+    if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
+      if sudo_credential_active; then
+        HAVE_SUDO_ACCESS="0"
+      else
+        HAVE_SUDO_ACCESS="1"
+      fi
+    fi
+    return "${HAVE_SUDO_ACCESS}"
+  fi
+
   GROUPS_CMD="$(which groups)"
 
   if [[ ! -x "/usr/bin/sudo" ]]; then
@@ -1136,6 +1153,23 @@ have_sudo_access() {
   fi
 
   return "${HAVE_SUDO_ACCESS}"
+}
+
+sudo_credential_active() {
+  [[ -x "/usr/bin/sudo" ]] && /usr/bin/sudo -n -v >/dev/null 2>&1
+}
+
+validate_external_sudo_credential() {
+  if sudo_credential_active; then
+    HAVE_SUDO_ACCESS="0"
+    return 0
+  fi
+
+  abort_multi "$(cat <<EOABORT
+bootbox external sudo mode requires an active sudo credential.
+the calling process must run \`sudo -v\` and maintain the credential before invoking bootbox.
+EOABORT
+)"
 }
 
 load_homebrew_shellenv() {
@@ -1997,6 +2031,14 @@ plan_brewfiles
 plan_ssh_keys
 plan_dotpkgs
 
+if external_sudo_enabled && no_sudo_enabled; then
+  abort_multi "$(cat <<EOABORT
+BOOTBOX_EXTERNAL_SUDO=1 cannot be combined with ${tty_bold}--no-sudo${tty_reset} or BOOTBOX_NO_SUDO=1.
+choose either caller-managed sudo or no sudo, not both.
+EOABORT
+)"
+fi
+
 if ! have_planned_actions; then
   finish_noop
 fi
@@ -2023,7 +2065,9 @@ EOABORT
 )"
 fi
 
-if needs_sudo && ! have_sudo_access; then
+if needs_sudo && external_sudo_enabled; then
+  validate_external_sudo_credential
+elif needs_sudo && ! have_sudo_access; then
   abort_multi "$(cat <<EOABORT
 ${tty_bold}${USER}${tty_reset} cannot write to ${tty_red}${TARGET}${tty_reset} or the expected Homebrew location ${tty_red}${HOMEBREW_PREFIX}${tty_reset} and is not a ${tty_bold}sudo${tty_reset} user.
 rerun setup with a sudoer or use --target to install into a directory ${tty_bold}${USER}${tty_reset} can write to.
@@ -2074,7 +2118,9 @@ execute() {
 execute_sudo() {
   local -a args=("$@")
   if sudo_enabled && [[ "${EUID:-${UID}}" != "0" ]] && have_sudo_access; then
-    if [[ -n "${SUDO_ASKPASS-}" ]]; then
+    if external_sudo_enabled; then
+      args=("-n" "${args[@]}")
+    elif [[ -n "${SUDO_ASKPASS-}" ]]; then
       args=("-A" "${args[@]}")
     fi
     execute "/usr/bin/sudo" "${args[@]}"
@@ -2104,7 +2150,7 @@ auto_mkdirp() {
   local perm_dir
   perm_dir="$(find_first_existing_parent "$dir")"
 
-  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_dir" ]]; then
+  if sudo_enabled && [[ ! -w "$perm_dir" ]] && have_sudo_access; then
     execute_sudo mkdir -p "$dir"
   else
     execute mkdir -p "$dir"
@@ -2120,7 +2166,7 @@ auto_mv() {
   perm_source="$(find_first_existing_parent "$source")"
   perm_dest="$(find_first_existing_parent "$dest")"
 
-  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_source" ||  ! -w "$perm_dest" ]]; then
+  if sudo_enabled && [[ ! -w "$perm_source" ||  ! -w "$perm_dest" ]] && have_sudo_access; then
     execute_sudo mv -f "$source" "$dest"
   else
     execute mv -f "$source" "$dest"
@@ -2134,7 +2180,7 @@ auto_cp_follow() {
   local perm_dest
   perm_dest="$(find_first_existing_parent "$dest")"
 
-  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_dest" ]]; then
+  if sudo_enabled && [[ ! -w "$perm_dest" ]] && have_sudo_access; then
     execute_sudo cp -RL "$source" "$dest"
   else
     execute cp -RL "$source" "$dest"
@@ -2147,7 +2193,7 @@ auto_rm() {
   local perm_dir
   perm_dir="$(find_first_existing_parent "$path")"
 
-  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_dir" ]]; then
+  if sudo_enabled && [[ ! -w "$perm_dir" ]] && have_sudo_access; then
     execute_sudo rm -f "$path"
   else
     execute rm -f "$path"
@@ -2161,7 +2207,7 @@ auto_chmod() {
   local perm_dir
   perm_dir="$(find_first_existing_parent "$path")"
 
-  if sudo_enabled && have_sudo_access && [[ ! -w "$perm_dir" ]]; then
+  if sudo_enabled && [[ ! -w "$perm_dir" ]] && have_sudo_access; then
     execute_sudo chmod "${mode}" "$path"
   else
     execute chmod "${mode}" "$path"
@@ -2169,7 +2215,7 @@ auto_chmod() {
 }
 
 # Invalidate sudo timestamp before exiting (if it wasn't active before).
-if sudo_enabled && [[ -x /usr/bin/sudo ]] && ! /usr/bin/sudo -n -v 2>/dev/null; then
+if sudo_enabled && ! external_sudo_enabled && [[ -x /usr/bin/sudo ]] && ! sudo_credential_active; then
   trap '/usr/bin/sudo -k' EXIT
 fi
 
@@ -2184,8 +2230,10 @@ if [[ -z "${NONINTERACTIVE-}" ]] && have_planned_actions; then
 fi
 
 # flag for password here if needed
-if sudo_enabled && needs_sudo; then
-  log "please enter ${tty_bold}sudo${tty_reset} password:"
+if sudo_enabled && ! external_sudo_enabled && needs_sudo; then
+  if ! sudo_credential_active; then
+    log "please enter ${tty_bold}sudo${tty_reset} password:"
+  fi
   execute_sudo true
 fi
 

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,44 @@
+# Leia Example Guidance
+
+This file applies when editing `examples/**/README.md`. These README files are executable Leia
+specs consumed in CI.
+
+## General Style
+
+- Prefer behavior-focused `# should` labels.
+- Keep each `# should` block focused on one observable contract.
+- Treat each blank-line-separated Leia block as a separate script. Do not rely on shell variables,
+  functions, or working-directory changes persisting across `should` blocks.
+- Prefer direct command pipelines, command substitutions, and deterministic inline values over
+  writing files just to inspect them later.
+- Prefer direct output assertions with `cmd 2>&1 | tee /dev/stderr | grep ...` or a focused `awk`
+  check over redirecting output to `.tmp/*.log` and grepping it later.
+- Do not capture command output into shell variables just to grep it later. If capture is needed to
+  preserve a failing command's status, print the captured output before assertions.
+
+## Fixtures
+
+- Keep fixtures beside the scenario README so each example stays self-contained.
+- Prefer committed example-local fixture binaries or files over generating long fixtures with
+  heredocs inside the README.
+- Hide repeated fixture environment and argument setup behind committed example-local helper scripts
+  when it makes README commands clearer.
+- Use `.tmp/` for scenario scratch data, logs, patched script copies, and helper internals.
+- Avoid braced shell variable expansions such as `${VAR}` in README command blocks when `$VAR` works.
+
+## Scenario Shape
+
+- Use `## Setup`, `## Testing`, and `## Destroy tests`.
+- Keep `Setup` focused on minimal prerequisites for the scenario.
+- Put commands immediately below each `# should ...` line with no blank lines inside the test body.
+- Separate one `# should ...` test from the next with a blank line.
+- Always include cleanup in `Destroy tests`, and remove only artifacts created by that scenario.
+
+## Local Validation
+
+- Do not run Leia examples locally as routine validation. They are CI-owned executable scenarios and
+  may mutate the machine.
+- Non-mutating CLI contract checks may be run locally when they are the touched surface and the user
+  has not asked to avoid local Leia execution.
+- Mutating runtime examples should be left to GitHub-hosted macOS CI unless the user explicitly asks
+  for local execution.

--- a/examples/bootbox-cli-contract/README.md
+++ b/examples/bootbox-cli-contract/README.md
@@ -59,6 +59,10 @@ if bootbox --help | grep -F -- '--ci'; then exit 1; fi
 # should keep the hidden core check out of help output
 if bootbox --help | grep -F -- '--check-core'; then exit 1; fi
 
+# should keep internal external sudo controls out of help output
+if bootbox --help | grep -F 'BOOTBOX_EXTERNAL_SUDO'; then exit 1; fi
+if bootbox --help | grep -F -- '--external-sudo'; then exit 1; fi
+
 # should print a version string
 test -n "$(bootbox --version)"
 

--- a/examples/bootbox-external-sudo/README.md
+++ b/examples/bootbox-external-sudo/README.md
@@ -1,0 +1,65 @@
+# Bootbox External Sudo Example
+
+This example verifies the hidden `BOOTBOX_EXTERNAL_SUDO=1` wrapper contract with example-local fake
+`sudo`, `brew`, and `stow` binaries. It keeps the production script hard-coded to `/usr/bin/sudo`,
+then patches only an example-local copy so the tests can observe credential checks, noninteractive
+sudo, and invalidation behavior without touching real machine sudo state.
+
+## Setup
+
+```bash
+# should prepare an example-local bootbox copy with fake sudo
+rm -rf .tmp && mkdir -p .tmp
+fake_sudo="$(pwd)/bin/sudo"
+sed "s|/usr/bin/sudo|$fake_sudo|g" "$(command -v bootbox)" > .tmp/bootbox
+chmod +x .tmp/bootbox
+```
+
+## Testing
+
+```bash
+# should use caller-owned sudo for privileged external mode
+bin/run-bootbox external-valid 2>&1 | tee /dev/stderr | awk '/please enter sudo password:/ { found=1 } END { exit found }'
+test -f .tmp/sudo-state/validated
+test -f .tmp/sudo-state/privileged_mkdir
+test ! -e .tmp/sudo-state/interactive
+test ! -e .tmp/sudo-state/invalidated
+
+# should fail before mutation when external sudo credential is unavailable
+{ ! bin/run-bootbox external-invalid; } 2>&1 | tee /dev/stderr | awk '
+  /bootbox external sudo mode requires an active sudo credential[.]/ { message=1 }
+  /sudo -v/ { remediation=1 }
+  /please enter sudo password:/ { prompt=1 }
+  END { if (message && remediation && !prompt) exit 0; exit 1 }
+'
+test -f .tmp/sudo-state/validated
+test ! -e .tmp/sudo-state/unexpected
+
+# should skip sudo validation when external mode does not need sudo
+bin/run-bootbox external-writable 2>&1 | tee /dev/stderr | awk '/please enter sudo password:/ { found=1 } END { exit found }'
+test ! -e .tmp/sudo-state/unexpected
+
+# should suppress standalone password message with cached credential
+bin/run-bootbox standalone-cached 2>&1 | tee /dev/stderr | awk '/please enter sudo password:/ { found=1 } END { exit found }'
+test -f .tmp/sudo-state/validated
+
+# should preserve standalone cold-cache sudo flow
+bin/run-bootbox standalone-cold 2>&1 | tee /dev/stderr | grep -F 'please enter sudo password:'
+test -f .tmp/sudo-state/prompted
+test -f .tmp/sudo-state/invalidated
+
+# should reject contradictory sudo modes
+{ ! bin/run-bootbox conflict; } 2>&1 | tee /dev/stderr | grep -F 'BOOTBOX_EXTERNAL_SUDO=1 cannot be combined with --no-sudo or BOOTBOX_NO_SUDO=1.'
+test ! -e .tmp/sudo-state/unexpected
+
+# should preserve no-sudo failure behavior when elevation is required
+{ ! bin/run-bootbox no-sudo; } 2>&1 | tee /dev/stderr | grep -F 'bootbox is running with --no-sudo'
+test ! -e .tmp/sudo-state/unexpected
+```
+
+## Destroy tests
+
+```bash
+# should remove the example scratch directory
+rm -rf .tmp
+```

--- a/examples/bootbox-external-sudo/bin/brew
+++ b/examples/bootbox-external-sudo/bin/brew
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+prefix="$(cd "$(dirname "$0")/.." && pwd)"
+
+case "${1:-}" in
+  --version)
+    printf "Homebrew 9.9.9\n"
+    ;;
+  --prefix)
+    printf "%s\n" "$prefix"
+    ;;
+  shellenv)
+    printf "export HOMEBREW_PREFIX=%q\n" "$prefix"
+    printf "export PATH=%q:\"\$PATH\"\n" "$prefix/bin"
+    ;;
+  list)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/examples/bootbox-external-sudo/bin/run-bootbox
+++ b/examples/bootbox-external-sudo/bin/run-bootbox
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+case_name="${1:-}"
+example_dir="$(cd "$(dirname "$0")/.." && pwd)"
+state_dir="$example_dir/.tmp/sudo-state"
+bootbox_path="$example_dir/.tmp/bootbox"
+sudo_case=""
+target="/private/var/root/bootbox-$case_name"
+dotpkg="dotpkgs/git"
+external_sudo=""
+no_sudo=""
+
+case "$case_name" in
+  external-valid)
+    external_sudo="1"
+    sudo_case="external-valid"
+    ;;
+  external-invalid)
+    external_sudo="1"
+    sudo_case="external-invalid"
+    ;;
+  external-writable)
+    external_sudo="1"
+    sudo_case="unexpected"
+    target="$example_dir/.tmp/writable-home"
+    ;;
+  standalone-cached)
+    sudo_case="standalone-cached"
+    ;;
+  standalone-cold)
+    sudo_case="standalone-cold"
+    ;;
+  conflict)
+    external_sudo="1"
+    no_sudo="1"
+    sudo_case="unexpected"
+    dotpkg=""
+    ;;
+  no-sudo)
+    no_sudo="1"
+    sudo_case="unexpected"
+    ;;
+  *)
+    printf "unknown external sudo example case: %s\n" "${case_name:-<empty>}" >&2
+    exit 2
+    ;;
+esac
+
+rm -rf "$state_dir"
+mkdir -p "$state_dir"
+
+cd "$example_dir"
+env \
+  ${external_sudo:+"BOOTBOX_EXTERNAL_SUDO=$external_sudo"} \
+  ${no_sudo:+"BOOTBOX_NO_SUDO=$no_sudo"} \
+  ${dotpkg:+"BOOTBOX_DOTPKG=$dotpkg"} \
+  EXAMPLE_SUDO_CASE="$sudo_case" \
+  EXAMPLE_SUDO_STATE_DIR="$state_dir" \
+  BOOTBOX_TARGET="$target" \
+  HOMEBREW_PREFIX="$example_dir" \
+  "$bootbox_path"

--- a/examples/bootbox-external-sudo/bin/stow
+++ b/examples/bootbox-external-sudo/bin/stow
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  printf "stow 2.4.1\n"
+  exit 0
+fi
+
+if [[ " $* " == *" --simulate "* ]]; then
+  printf "LINK: .gitconfig => dotpkgs/git/.gitconfig\n"
+  exit 0
+fi
+
+exit 0

--- a/examples/bootbox-external-sudo/bin/sudo
+++ b/examples/bootbox-external-sudo/bin/sudo
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+mark() {
+  local name="$1"
+
+  if [[ -n "${EXAMPLE_SUDO_STATE_DIR:-}" ]]; then
+    mkdir -p "$EXAMPLE_SUDO_STATE_DIR"
+    : > "$EXAMPLE_SUDO_STATE_DIR/$name"
+  fi
+}
+
+case "${EXAMPLE_SUDO_CASE:-valid}" in
+  external-valid)
+    if [[ "${1:-}" == "-n" && "${2:-}" == "-v" ]]; then
+      mark validated
+      exit 0
+    fi
+    if [[ " $* " == *" -k "* ]] || [[ " $* " == *" -K "* ]]; then
+      mark invalidated
+      exit 1
+    fi
+    if [[ "${1:-}" != "-n" ]]; then
+      mark interactive
+      exit 1
+    fi
+    if [[ "$*" == "-n mkdir -p /private/var/root/bootbox-external-valid" ]]; then
+      mark privileged_mkdir
+    fi
+    exit 0
+    ;;
+  external-invalid)
+    if [[ "${1:-}" == "-n" && "${2:-}" == "-v" ]]; then
+      mark validated
+      exit 1
+    fi
+    mark unexpected
+    exit 1
+    ;;
+  unexpected)
+    mark unexpected
+    exit 1
+    ;;
+  standalone-cached)
+    if [[ "${1:-}" == "-n" && "${2:-}" == "-v" ]]; then
+      mark validated
+      exit 0
+    fi
+    exit 0
+    ;;
+  standalone-cold)
+    if [[ "${1:-}" == "-n" && "${2:-}" == "-v" ]]; then
+      mark validation_failed
+      exit 1
+    fi
+    if [[ "${1:-}" == "true" ]]; then
+      mark prompted
+      exit 0
+    fi
+    if [[ "${1:-}" == "-k" ]]; then
+      mark invalidated
+      exit 0
+    fi
+    exit 0
+    ;;
+  valid)
+    exit 0
+    ;;
+  *)
+    printf "unknown fake sudo case: %s\n" "$EXAMPLE_SUDO_CASE" >&2
+    exit 2
+    ;;
+esac

--- a/examples/bootbox-external-sudo/dotpkgs/git/.gitconfig
+++ b/examples/bootbox-external-sudo/dotpkgs/git/.gitconfig
@@ -1,0 +1,2 @@
+[user]
+  name = Bootbox Sudo Lifecycle


### PR DESCRIPTION
## Summary

- add hidden `BOOTBOX_EXTERNAL_SUDO=1` support for caller-managed sudo sessions
- use noninteractive sudo validation and execution in external mode, while preserving standalone sudo lifecycle behavior
- add focused Leia coverage for external sudo behavior, hidden CLI contract assertions, and example-local Leia guidance

## Validation

- `./node_modules/.bin/shellcheck examples/bootbox-external-sudo/bin/brew examples/bootbox-external-sudo/bin/stow examples/bootbox-external-sudo/bin/sudo examples/bootbox-external-sudo/bin/run-bootbox`
- `bun run lint`
- `git diff --check`

Mutating Leia examples were not run locally; this PR adds `bootbox-external-sudo` to the GitHub-hosted example matrix so CI can exercise it.